### PR TITLE
fix: correct infinite loop for continuation token

### DIFF
--- a/cmd/models/list.go
+++ b/cmd/models/list.go
@@ -33,13 +33,13 @@ func listModels(fgaClient client.SdkClient, maxPages int) (string, error) {
 	// This is needed to ensure empty array is marshaled as [] instead of nil
 	models := make([]openfga.AuthorizationModel, 0)
 
-	var continuationToken *string
+	var continuationToken string
 
 	pageIndex := 0
 
 	for {
 		options := client.ClientReadAuthorizationModelsOptions{
-			ContinuationToken: continuationToken,
+			ContinuationToken: &continuationToken,
 		}
 
 		response, err := fgaClient.ReadAuthorizationModels(context.Background()).Options(options).Execute()
@@ -51,11 +51,11 @@ func listModels(fgaClient client.SdkClient, maxPages int) (string, error) {
 
 		pageIndex++
 
-		continuationToken = response.ContinuationToken
-
-		if continuationToken == nil || pageIndex > maxPages {
+		if response.ContinuationToken == nil || *response.ContinuationToken == continuationToken || pageIndex > maxPages {
 			break
 		}
+
+		continuationToken = *response.ContinuationToken
 	}
 
 	modelsJSON, err := json.Marshal(openfga.ReadAuthorizationModelsResponse{AuthorizationModels: &models})

--- a/cmd/models/list_test.go
+++ b/cmd/models/list_test.go
@@ -29,13 +29,13 @@ func TestListModelsEmpty(t *testing.T) {
 
 	response := openfga.ReadAuthorizationModelsResponse{
 		AuthorizationModels: &models,
-		ContinuationToken:   nil,
+		ContinuationToken:   openfga.PtrString(""),
 	}
 	mockExecute.EXPECT().Execute().Return(&response, nil)
 
 	mockRequest := mockclient.NewMockSdkClientReadAuthorizationModelsRequestInterface(mockCtrl)
 	options := client.ClientReadAuthorizationModelsOptions{
-		ContinuationToken: nil,
+		ContinuationToken: openfga.PtrString(""),
 	}
 	mockRequest.EXPECT().Options(options).Return(mockExecute)
 	mockFgaClient.EXPECT().ReadAuthorizationModels(context.Background()).Return(mockRequest)
@@ -64,7 +64,7 @@ func TestListModelsFail(t *testing.T) {
 
 	mockRequest := mockclient.NewMockSdkClientReadAuthorizationModelsRequestInterface(mockCtrl)
 	options := client.ClientReadAuthorizationModelsOptions{
-		ContinuationToken: nil,
+		ContinuationToken: openfga.PtrString(""),
 	}
 	mockRequest.EXPECT().Options(options).Return(mockExecute)
 	mockFgaClient.EXPECT().ReadAuthorizationModels(context.Background()).Return(mockRequest)
@@ -96,13 +96,13 @@ func TestListModelsSinglePage(t *testing.T) {
 
 	response := openfga.ReadAuthorizationModelsResponse{
 		AuthorizationModels: &models,
-		ContinuationToken:   nil,
+		ContinuationToken:   openfga.PtrString(""),
 	}
 	mockExecute.EXPECT().Execute().Return(&response, nil)
 
 	mockRequest := mockclient.NewMockSdkClientReadAuthorizationModelsRequestInterface(mockCtrl)
 	options := client.ClientReadAuthorizationModelsOptions{
-		ContinuationToken: nil,
+		ContinuationToken: openfga.PtrString(""),
 	}
 	mockRequest.EXPECT().Options(options).Return(mockExecute)
 	mockFgaClient.EXPECT().ReadAuthorizationModels(context.Background()).Return(mockRequest)
@@ -144,7 +144,7 @@ func TestListModelsMultiPage(t *testing.T) {
 
 	mockRequest1 := mockclient.NewMockSdkClientReadAuthorizationModelsRequestInterface(mockCtrl)
 	options1 := client.ClientReadAuthorizationModelsOptions{
-		ContinuationToken: nil,
+		ContinuationToken: openfga.PtrString(""),
 	}
 
 	mockExecute2 := mockclient.NewMockSdkClientReadAuthorizationModelsRequestInterface(mockCtrl)
@@ -161,7 +161,7 @@ func TestListModelsMultiPage(t *testing.T) {
 	}
 	response2 := openfga.ReadAuthorizationModelsResponse{
 		AuthorizationModels: &models2,
-		ContinuationToken:   nil,
+		ContinuationToken:   continuationToken1,
 	}
 
 	gomock.InOrder(
@@ -220,7 +220,7 @@ func TestListModelsMultiPageMaxPage(t *testing.T) {
 
 	mockRequest1 := mockclient.NewMockSdkClientReadAuthorizationModelsRequestInterface(mockCtrl)
 	options1 := client.ClientReadAuthorizationModelsOptions{
-		ContinuationToken: nil,
+		ContinuationToken: openfga.PtrString(""),
 	}
 
 	mockExecute1.EXPECT().Execute().Return(&response1, nil)

--- a/cmd/stores/list.go
+++ b/cmd/stores/list.go
@@ -48,11 +48,11 @@ var listCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		stores := []openfga.Store{}
-		var continuationToken *string
+		continuationToken := ""
 		pageIndex := 0
 		for {
 			options := client.ClientListStoresOptions{
-				ContinuationToken: continuationToken,
+				ContinuationToken: &continuationToken,
 			}
 			response, err := fgaClient.ListStores(context.Background()).Options(options).Execute()
 			if err != nil {
@@ -62,11 +62,11 @@ var listCmd = &cobra.Command{
 
 			stores = append(stores, *response.Stores...)
 			pageIndex++
-			if continuationToken == nil || pageIndex >= maxPages {
+			if response.ContinuationToken == nil || *response.ContinuationToken == continuationToken || pageIndex >= maxPages {
 				break
 			}
 
-			continuationToken = response.ContinuationToken
+			continuationToken = *response.ContinuationToken
 		}
 
 		storesJSON, err := json.Marshal(openfga.ListStoresResponse{Stores: &stores})

--- a/cmd/tuples/read.go
+++ b/cmd/tuples/read.go
@@ -67,11 +67,11 @@ var readCmd = &cobra.Command{
 		}
 
 		tuples := []openfga.Tuple{}
-		var continuationToken *string
+		continuationToken := ""
 		pageIndex := 0
 		options := client.ClientReadOptions{}
 		for {
-			options.ContinuationToken = continuationToken
+			options.ContinuationToken = &continuationToken
 			response, err := fgaClient.Read(context.Background()).Body(*body).Options(options).Execute()
 			if err != nil {
 				fmt.Printf("Failed to read tuples due to %v", err)
@@ -80,11 +80,11 @@ var readCmd = &cobra.Command{
 
 			tuples = append(tuples, *response.Tuples...)
 			pageIndex++
-			if continuationToken == nil || pageIndex >= maxPages {
+			if response.ContinuationToken == nil || *response.ContinuationToken == continuationToken || pageIndex >= maxPages {
 				break
 			}
 
-			continuationToken = response.ContinuationToken
+			continuationToken = *response.ContinuationToken
 		}
 
 		tuplesJSON, err := json.Marshal(openfga.ReadResponse{Tuples: &tuples})


### PR DESCRIPTION

## Description
Correct possible infinite loop as continuation token not used correctly.

## References
Close https://github.com/openfga/cli/issues/28

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
