### PR TITLE
fix: empty coninuation token means last page

### DIFF
--- a/cmd/models/list.go
+++ b/cmd/models/list.go
@@ -51,7 +51,7 @@ func listModels(fgaClient client.SdkClient, maxPages int) (string, error) {
 
 		pageIndex++
 
-		if response.ContinuationToken == nil || *response.ContinuationToken == continuationToken || pageIndex > maxPages {
+		if response.ContinuationToken == nil || *response.ContinuationToken == "" || pageIndex > maxPages {
 			break
 		}
 

--- a/cmd/models/list_test.go
+++ b/cmd/models/list_test.go
@@ -159,9 +159,10 @@ func TestListModelsMultiPage(t *testing.T) {
 	models2 := []openfga.AuthorizationModel{
 		model2,
 	}
+	emptyToken := ""
 	response2 := openfga.ReadAuthorizationModelsResponse{
 		AuthorizationModels: &models2,
-		ContinuationToken:   continuationToken1,
+		ContinuationToken:   &emptyToken,
 	}
 
 	gomock.InOrder(

--- a/cmd/stores/list_test.go
+++ b/cmd/stores/list_test.go
@@ -1,0 +1,246 @@
+package stores
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	mockclient "github.com/openfga/cli/mocks"
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/client"
+)
+
+var errMockListStores = errors.New("mock error")
+
+func TestListStoresError(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+
+	var response openfga.ListStoresResponse
+
+	mockExecute.EXPECT().Execute().Return(&response, errMockListStores)
+
+	mockRequest := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+	options := client.ClientListStoresOptions{
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+	mockFgaClient.EXPECT().ListStores(context.Background()).Return(mockRequest)
+
+	_, err := listStores(mockFgaClient, 5)
+	if err == nil {
+		t.Error("Expect error but there is none")
+	}
+}
+
+func TestListStoresEmpty(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+
+	var stores []openfga.Store
+
+	response := openfga.ListStoresResponse{
+		Stores:            &stores,
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockExecute.EXPECT().Execute().Return(&response, nil)
+
+	mockRequest := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+	options := client.ClientListStoresOptions{
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+	mockFgaClient.EXPECT().ListStores(context.Background()).Return(mockRequest)
+
+	output, err := listStores(mockFgaClient, 5)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedOutput := "{\"stores\":[]}"
+	if output != expectedOutput {
+		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+	}
+}
+
+func TestListStoresSinglePage(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+
+	expectedTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+	stores := []openfga.Store{
+		{
+			Id:        openfga.PtrString("12345"),
+			Name:      openfga.PtrString("foo"),
+			CreatedAt: &expectedTime,
+			UpdatedAt: &expectedTime,
+		},
+	}
+
+	response := openfga.ListStoresResponse{
+		Stores:            &stores,
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockExecute.EXPECT().Execute().Return(&response, nil)
+
+	mockRequest := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+	options := client.ClientListStoresOptions{
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+	mockFgaClient.EXPECT().ListStores(context.Background()).Return(mockRequest)
+
+	output, err := listStores(mockFgaClient, 5)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedOutput := "{\"stores\":[{\"created_at\":\"2009-11-10T23:00:00Z\",\"id\":\"12345\",\"name\":\"foo\",\"updated_at\":\"2009-11-10T23:00:00Z\"}]}" //nolint:lll
+	if output != expectedOutput {
+		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+	}
+}
+
+func TestListStoresMultiPage(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	const continuationToken = "01GXSA8YR785C4FYS3C0RTG7B2" //nolint:gosec
+
+	mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+
+	mockExecute1 := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+
+	expectedTime1 := time.Date(2009, time.November, 10, 22, 0, 0, 0, time.UTC)
+
+	stores1 := []openfga.Store{
+		{
+			Id:        openfga.PtrString("abcde"),
+			Name:      openfga.PtrString("moo"),
+			CreatedAt: &expectedTime1,
+			UpdatedAt: &expectedTime1,
+		},
+	}
+
+	response1 := openfga.ListStoresResponse{
+		Stores:            &stores1,
+		ContinuationToken: openfga.PtrString(continuationToken),
+	}
+
+	mockExecute2 := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+
+	expectedTime2 := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+	stores2 := []openfga.Store{
+		{
+			Id:        openfga.PtrString("12345"),
+			Name:      openfga.PtrString("foo"),
+			CreatedAt: &expectedTime2,
+			UpdatedAt: &expectedTime2,
+		},
+	}
+
+	response2 := openfga.ListStoresResponse{
+		Stores:            &stores2,
+		ContinuationToken: openfga.PtrString(""),
+	}
+	gomock.InOrder(
+		mockExecute1.EXPECT().Execute().Return(&response1, nil),
+		mockExecute2.EXPECT().Execute().Return(&response2, nil),
+	)
+
+	mockRequest1 := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+	options1 := client.ClientListStoresOptions{
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockRequest2 := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+	options2 := client.ClientListStoresOptions{
+		ContinuationToken: openfga.PtrString(continuationToken),
+	}
+	gomock.InOrder(
+		mockRequest1.EXPECT().Options(options1).Return(mockExecute1),
+		mockRequest2.EXPECT().Options(options2).Return(mockExecute2),
+	)
+	gomock.InOrder(
+		mockFgaClient.EXPECT().ListStores(context.Background()).Return(mockRequest1),
+		mockFgaClient.EXPECT().ListStores(context.Background()).Return(mockRequest2),
+	)
+
+	output, err := listStores(mockFgaClient, 5)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedOutput := "{\"stores\":[{\"created_at\":\"2009-11-10T22:00:00Z\",\"id\":\"abcde\",\"name\":\"moo\",\"updated_at\":\"2009-11-10T22:00:00Z\"},{\"created_at\":\"2009-11-10T23:00:00Z\",\"id\":\"12345\",\"name\":\"foo\",\"updated_at\":\"2009-11-10T23:00:00Z\"}]}" //nolint:lll
+	if output != expectedOutput {
+		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+	}
+}
+
+func TestListStoresMultiPageMaxPage(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	const continuationToken = "01GXSA8YR785C4FYS3C0RTG7B2" //nolint:gosec
+
+	mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+
+	mockExecute1 := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+
+	expectedTime1 := time.Date(2009, time.November, 10, 22, 0, 0, 0, time.UTC)
+
+	stores1 := []openfga.Store{
+		{
+			Id:        openfga.PtrString("abcde"),
+			Name:      openfga.PtrString("moo"),
+			CreatedAt: &expectedTime1,
+			UpdatedAt: &expectedTime1,
+		},
+	}
+
+	response1 := openfga.ListStoresResponse{
+		Stores:            &stores1,
+		ContinuationToken: openfga.PtrString(continuationToken),
+	}
+
+	mockExecute1.EXPECT().Execute().Return(&response1, nil)
+
+	mockRequest1 := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+	options1 := client.ClientListStoresOptions{
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockRequest1.EXPECT().Options(options1).Return(mockExecute1)
+	mockFgaClient.EXPECT().ListStores(context.Background()).Return(mockRequest1)
+
+	output, err := listStores(mockFgaClient, 1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedOutput := "{\"stores\":[{\"created_at\":\"2009-11-10T22:00:00Z\",\"id\":\"abcde\",\"name\":\"moo\",\"updated_at\":\"2009-11-10T22:00:00Z\"}]}" //nolint:lll
+	if output != expectedOutput {
+		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+	}
+}

--- a/cmd/tuples/read.go
+++ b/cmd/tuples/read.go
@@ -26,6 +26,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// MaxReadPagesLength Limit the tuples so that we are not paginating indefinitely.
+var MaxReadPagesLength = 20
+
 func read(fgaClient client.SdkClient, user string, relation string, object string, maxPages int) (string, error) {
 	body := &client.ClientReadRequest{}
 	if user != "" {
@@ -108,5 +111,5 @@ func init() {
 	readCmd.Flags().String("user", "", "User")
 	readCmd.Flags().String("relation", "", "Relation")
 	readCmd.Flags().String("object", "", "Object")
-	readCmd.Flags().Int("max-pages", MaxReadChangesPagesLength, "Max number of pages to get.")
+	readCmd.Flags().Int("max-pages", MaxReadPagesLength, "Max number of pages to get.")
 }

--- a/cmd/tuples/read_test.go
+++ b/cmd/tuples/read_test.go
@@ -1,0 +1,306 @@
+package tuples
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	mock_client "github.com/openfga/cli/mocks"
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/client"
+)
+
+var errMockRead = errors.New("mock error")
+
+func TestReadError(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mock_client.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	var response openfga.ReadResponse
+
+	mockExecute.EXPECT().Execute().Return(&response, errMockRead)
+
+	mockRequest := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+	options := client.ClientReadOptions{
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+
+	mockBody := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	body := client.ClientReadRequest{
+		User:     openfga.PtrString("user:user1"),
+		Relation: openfga.PtrString("reader"),
+		Object:   openfga.PtrString("document:doc1"),
+	}
+	mockBody.EXPECT().Body(body).Return(mockRequest)
+
+	mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody)
+
+	_, err := read(mockFgaClient, "user:user1", "reader", "document:doc1", 5)
+	if err == nil {
+		t.Error("Expect error but there is none")
+	}
+}
+
+func TestReadEmpty(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mock_client.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	var tuples []openfga.Tuple
+	response := openfga.ReadResponse{
+		Tuples:            &tuples,
+		ContinuationToken: openfga.PtrString(""),
+	}
+
+	mockExecute.EXPECT().Execute().Return(&response, nil)
+
+	mockRequest := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+	options := client.ClientReadOptions{
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+
+	mockBody := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	body := client.ClientReadRequest{
+		User:     openfga.PtrString("user:user1"),
+		Relation: openfga.PtrString("reader"),
+		Object:   openfga.PtrString("document:doc1"),
+	}
+	mockBody.EXPECT().Body(body).Return(mockRequest)
+
+	mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody)
+
+	output, err := read(mockFgaClient, "user:user1", "reader", "document:doc1", 5)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedOutput := "{\"tuples\":[]}"
+	if output != expectedOutput {
+		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+	}
+}
+
+func TestReadSinglePage(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mock_client.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	key1 := openfga.NewTupleKey()
+	key1.Object = openfga.PtrString("document:doc1")
+	key1.Relation = openfga.PtrString("reader")
+	key1.User = openfga.PtrString("user:user1")
+
+	changesTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+	tuples := []openfga.Tuple{
+		{
+			Key:       key1,
+			Timestamp: &changesTime,
+		},
+	}
+	response := openfga.ReadResponse{
+		Tuples:            &tuples,
+		ContinuationToken: openfga.PtrString(""),
+	}
+
+	mockExecute.EXPECT().Execute().Return(&response, nil)
+
+	mockRequest := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+	options := client.ClientReadOptions{
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+
+	mockBody := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	body := client.ClientReadRequest{
+		User:     openfga.PtrString("user:user1"),
+		Relation: openfga.PtrString("reader"),
+		Object:   openfga.PtrString("document:doc1"),
+	}
+	mockBody.EXPECT().Body(body).Return(mockRequest)
+
+	mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody)
+
+	output, err := read(mockFgaClient, "user:user1", "reader", "document:doc1", 5)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedOutput := "{\"tuples\":[{\"key\":{\"object\":\"document:doc1\",\"relation\":\"reader\",\"user\":\"user:user1\"},\"timestamp\":\"2009-11-10T23:00:00Z\"}]}" //nolint:lll
+	if output != expectedOutput {
+		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+	}
+}
+
+func TestReadMultiPages(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mock_client.NewMockSdkClient(mockCtrl)
+
+	const continuationToken = "01GXSA8YR785C4FYS3C0RTG7B2" //nolint:gosec
+
+	mockExecute1 := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	key1 := openfga.NewTupleKey()
+	key1.Object = openfga.PtrString("document:doc1")
+	key1.Relation = openfga.PtrString("reader")
+	key1.User = openfga.PtrString("user:user1")
+
+	changesTime1 := time.Date(2009, time.November, 10, 22, 0, 0, 0, time.UTC)
+
+	tuples1 := []openfga.Tuple{
+		{
+			Key:       key1,
+			Timestamp: &changesTime1,
+		},
+	}
+	response1 := openfga.ReadResponse{
+		Tuples:            &tuples1,
+		ContinuationToken: openfga.PtrString(continuationToken),
+	}
+
+	mockExecute2 := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	key2 := openfga.NewTupleKey()
+	key2.Object = openfga.PtrString("document:doc2")
+	key2.Relation = openfga.PtrString("reader")
+	key2.User = openfga.PtrString("user:user1")
+
+	changesTime2 := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+	tuples2 := []openfga.Tuple{
+		{
+			Key:       key2,
+			Timestamp: &changesTime2,
+		},
+	}
+	response2 := openfga.ReadResponse{
+		Tuples:            &tuples2,
+		ContinuationToken: openfga.PtrString(""),
+	}
+
+	gomock.InOrder(
+		mockExecute1.EXPECT().Execute().Return(&response1, nil),
+		mockExecute2.EXPECT().Execute().Return(&response2, nil),
+	)
+
+	mockRequest1 := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+	options1 := client.ClientReadOptions{
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockRequest2 := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+	options2 := client.ClientReadOptions{
+		ContinuationToken: openfga.PtrString(continuationToken),
+	}
+	gomock.InOrder(
+		mockRequest1.EXPECT().Options(options1).Return(mockExecute1),
+		mockRequest2.EXPECT().Options(options2).Return(mockExecute2),
+	)
+
+	mockBody1 := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+	mockBody2 := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	body := client.ClientReadRequest{
+		User:     openfga.PtrString("user:user1"),
+		Relation: openfga.PtrString("reader"),
+		Object:   openfga.PtrString("document:doc1"),
+	}
+	gomock.InOrder(
+		mockBody1.EXPECT().Body(body).Return(mockRequest1),
+		mockBody2.EXPECT().Body(body).Return(mockRequest2),
+	)
+
+	gomock.InOrder(
+		mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody1),
+		mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody2),
+	)
+
+	output, err := read(mockFgaClient, "user:user1", "reader", "document:doc1", 5)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedOutput := `{"tuples":[{"key":{"object":"document:doc1","relation":"reader","user":"user:user1"},"timestamp":"2009-11-10T22:00:00Z"},{"key":{"object":"document:doc2","relation":"reader","user":"user:user1"},"timestamp":"2009-11-10T23:00:00Z"}]}` //nolint:lll
+	if output != expectedOutput {
+		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+	}
+}
+
+func TestReadMultiPagesMaxLimit(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mock_client.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	key1 := openfga.NewTupleKey()
+	key1.Object = openfga.PtrString("document:doc1")
+	key1.Relation = openfga.PtrString("reader")
+	key1.User = openfga.PtrString("user:user1")
+
+	changesTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+	tuples := []openfga.Tuple{
+		{
+			Key:       key1,
+			Timestamp: &changesTime,
+		},
+	}
+	response := openfga.ReadResponse{
+		Tuples:            &tuples,
+		ContinuationToken: openfga.PtrString("ABCDEFG"),
+	}
+
+	mockExecute.EXPECT().Execute().Return(&response, nil)
+
+	mockRequest := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+	options := client.ClientReadOptions{
+		ContinuationToken: openfga.PtrString(""),
+	}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+
+	mockBody := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
+
+	body := client.ClientReadRequest{
+		User:     openfga.PtrString("user:user1"),
+		Relation: openfga.PtrString("reader"),
+		Object:   openfga.PtrString("document:doc1"),
+	}
+	mockBody.EXPECT().Body(body).Return(mockRequest)
+
+	mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody)
+
+	output, err := read(mockFgaClient, "user:user1", "reader", "document:doc1", 1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedOutput := "{\"tuples\":[{\"key\":{\"object\":\"document:doc1\",\"relation\":\"reader\",\"user\":\"user:user1\"},\"timestamp\":\"2009-11-10T23:00:00Z\"}]}" //nolint:lll
+	if output != expectedOutput {
+		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+	}
+}


### PR DESCRIPTION
## Description
Fix the infinite loop problem when continuation token is empty

## References
follow up of https://github.com/openfga/cli/pull/29 

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
