### PR TITLE
chore: bump go-sdk version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/golang/mock v1.6.0
-	github.com/openfga/go-sdk v0.2.3-0.20230628172854-99f80f68e981
+	github.com/openfga/go-sdk v0.2.3-0.20230706193033-786d614eebbd
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.16.0
 )

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/openfga/go-sdk v0.2.3-0.20230628172854-99f80f68e981 h1:O4pso4WIqOlk7Onngw69mbu0smerYFVsW6hkyShNDmk=
 github.com/openfga/go-sdk v0.2.3-0.20230628172854-99f80f68e981/go.mod h1:ZB13O8GilPc0ITWssOszgxmz6CnIe8PQLZqbqAnx2IY=
+github.com/openfga/go-sdk v0.2.3-0.20230706193033-786d614eebbd h1:T/gza+TXR9Ld9FQIOzZhitmFQ+k7k6F8fUFG8NtrWBc=
+github.com/openfga/go-sdk v0.2.3-0.20230706193033-786d614eebbd/go.mod h1:ZB13O8GilPc0ITWssOszgxmz6CnIe8PQLZqbqAnx2IY=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION

## Description
Fix issue where CLI fails when auth model id not provided

## References
 Close https://github.com/openfga/cli/issues/47


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
