### PR TITLE
fix: expand to expect correct number of parameter

### DIFF
--- a/cmd/query/expand.go
+++ b/cmd/query/expand.go
@@ -46,10 +46,11 @@ func expand(fgaClient client.SdkClient, relation string, object string) (string,
 
 // expandCmd represents the expand command.
 var expandCmd = &cobra.Command{
-	Use:   "expand",
-	Short: "Expand",
-	Long:  "Expands the relationships in userset tree format.",
-	Args:  cobra.ExactArgs(1),
+	Use:     "expand",
+	Short:   "Expand",
+	Long:    "Expands the relationships in userset tree format.",
+	Example: "fga query expand --store-id=\"01H4P8Z95KTXXEP6Z03T75Q984\" can_view document:roadmap",
+	Args:    cobra.ExactArgs(2), //nolint:gomnd
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 


### PR DESCRIPTION

## Description
Fix expand to use correct number of parameter


## References
Close https://github.com/openfga/cli/issues/51

## Test

Run `./fga query expand --store-id="01H4PBMQC927DTAWD8P64CVA4W" owner doc:roadmap` and see the correct result

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
