### PR TITLE
feat: load flags from  env & config file

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,7 @@ linters-settings:
         allow:
           - $gostd
           - github.com/spf13/cobra
+          - github.com/spf13/pflag
           - github.com/spf13/viper
           - github.com/openfga/cli
           - github.com/openfga/go-sdk

--- a/README.md
+++ b/README.md
@@ -93,14 +93,16 @@ Make sure you have Go 1.20 or later installed. See the [Go downloads](https://go
 
 For any command that interacts with an OpenFGA server, these configuration values can be passed (where applicable)
 
-| Name           | Flag                 | CLI                    |
-|----------------|----------------------|------------------------|
-| Server Url     | `--server-url`       | `FGA_SERVER_URL`       |
-| Shared Secret  | `--api-token`        | `FGA_API_TOKEN`        |
-| Client ID      | `--client-id`        | `FGA_CLIENT_ID`        |
-| Client Secret  | `--client-secret`    | `FGA_CLIENT_SECRET`    |
-| Token Issuer   | `--api-token-issuer` | `FGA_API_TOKEN_ISSUER` |
-| Token Audience | `--api-audience`     | `FGA_API_AUDIENCE`     |
+| Name                   | Flag                 | CLI                    |
+|------------------------|----------------------|------------------------|
+| Server Url             | `--server-url`       | `FGA_SERVER_URL`       |
+| Shared Secret          | `--api-token`        | `FGA_API_TOKEN`        |
+| Client ID              | `--client-id`        | `FGA_CLIENT_ID`        |
+| Client Secret          | `--client-secret`    | `FGA_CLIENT_SECRET`    |
+| Token Issuer           | `--api-token-issuer` | `FGA_API_TOKEN_ISSUER` |
+| Token Audience         | `--api-audience`     | `FGA_API_AUDIENCE`     |
+| Store ID               | `--store-id`         | `FGA_STORE_ID`         |
+| Authorization Model ID | `--model-id`         | `FGA_MODEL_ID`         |
 
 ### Commands
 

--- a/lib/cmd-utils/bind-viper-to-flags.go
+++ b/lib/cmd-utils/bind-viper-to-flags.go
@@ -1,0 +1,26 @@
+package cmdutils
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// BindViperToFlags recursively binds viper configs to cobra commands and subcommands.
+func BindViperToFlags(cmd *cobra.Command, viperInstance *viper.Viper) {
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		configName := flag.Name
+
+		if !flag.Changed && viperInstance.IsSet(configName) {
+			value := viperInstance.Get(configName)
+			err := cmd.Flags().Set(flag.Name, fmt.Sprintf("%v", value))
+			cobra.CheckErr(err)
+		}
+	})
+
+	for _, subcmd := range cmd.Commands() {
+		BindViperToFlags(subcmd, viperInstance)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
<img width="1655" alt="Screenshot 2023-07-07 at 6 49 16 PM" src="https://github.com/openfga/cli/assets/536147/e8b05482-8cb4-4f42-83aa-c720738ba6ee">

I'm leaving the config file bit undocumented for now, but if anyone wants to try it, you can place `.fga.yaml` in your home directory or in your user config directory or under the `fga` folder of your config directory.

The contents of the file are of this format:
```yaml
server-url: http://localhost:8080
store-id: 01FQH7RTCYK15CAJS9FQGMCKPY
model-id: 01GVKXGDCV2SMG6TRE9NMBQ2VG
```

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
closes #12
closes #37  

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
