### PR TITLE
fix: correct behaviour if model has empty relations

### DIFF
--- a/cmd/query/list-relations.go
+++ b/cmd/query/list-relations.go
@@ -83,6 +83,13 @@ func listRelations(clientConfig fga.ClientConfig,
 		}
 
 		relations = *relationsForType
+
+		if len(relations) < 1 {
+			// there is still no relations.  This means for the model, the corresponding object's type has no relations
+			return &client.ClientListRelationsResponse{
+				Relations: []string{},
+			}, nil
+		}
 	}
 
 	body := &client.ClientListRelationsRequest{


### PR DESCRIPTION
## Description
If model reports there is no relations, we should short-circuit and returns empty relations.

## References
Close https://github.com/openfga/cli/issues/61

## Testing
Based on https://github.com/openfga/cli/issues/61, output will be

```
 ./fga query list-relations --store-id 01H4S674PM9E2Z10YAPQZ15XFF doc:xxx user:xxx
{
  "relations": []
}
```

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
