### PR TITLE
feat: add `fga version` command to the CLI

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,7 @@ func init() {
 		"client-secret",
 	)
 
+	rootCmd.Version = versionStr
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(store.StoreCmd)
 	rootCmd.AddCommand(model.ModelCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,7 @@ func init() {
 		"client-secret",
 	)
 
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(store.StoreCmd)
 	rootCmd.AddCommand(model.ModelCmd)
 	rootCmd.AddCommand(tuple.TupleCmd)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,8 +10,8 @@ import (
 // versionCmd is the entrypoint for the `fga version“ command.
 var versionCmd *cobra.Command = &cobra.Command{
 	Use:   "version",
-	Short: "Reports the OpenFGA CLI version",
-	Long:  "Reports the OpenFGA CLI version.",
+	Short: "Reports the FGA CLI version",
+	Long:  "Reports the FGA CLI version.",
 	RunE:  version,
 	Args:  cobra.NoArgs,
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,5 +18,6 @@ var versionCmd *cobra.Command = &cobra.Command{
 
 func version(_ *cobra.Command, _ []string) error {
 	log.Printf("version `%s` build from `%s` on `%s` ", build.Version, build.Commit, build.Date)
+
 	return nil
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/openfga/cli/internal/build"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd is the entrypoint for the `fga version“ command.
+var versionCmd *cobra.Command = &cobra.Command{
+	Use:   "version",
+	Short: "Reports the OpenFGA CLI version",
+	Long:  "Reports the OpenFGA CLI version.",
+	RunE:  version,
+	Args:  cobra.NoArgs,
+}
+
+func version(_ *cobra.Command, _ []string) error {
+	log.Printf("version `%s` build from `%s` on `%s` ", build.Version, build.Commit, build.Date)
+	return nil
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var versionStr = fmt.Sprintf("version `%s` build from `%s` on `%s` ", build.Version, build.Commit, build.Date)
+var versionStr = fmt.Sprintf("`%s` (commit: `%s`, date: `%s`)", build.Version, build.Commit, build.Date)
 
 // versionCmd is the entrypoint for the `fga version“ command.
 var versionCmd *cobra.Command = &cobra.Command{
@@ -15,7 +15,7 @@ var versionCmd *cobra.Command = &cobra.Command{
 	Short: "Reports the FGA CLI version",
 	Long:  "Reports the FGA CLI version.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println(versionStr)
+		fmt.Printf("fga version %s\n", versionStr)
 
 		return nil
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,23 +1,23 @@
 package cmd
 
 import (
-	"log"
+	"fmt"
 
 	"github.com/openfga/cli/internal/build"
 	"github.com/spf13/cobra"
 )
+
+var versionStr = fmt.Sprintf("version `%s` build from `%s` on `%s` ", build.Version, build.Commit, build.Date)
 
 // versionCmd is the entrypoint for the `fga version“ command.
 var versionCmd *cobra.Command = &cobra.Command{
 	Use:   "version",
 	Short: "Reports the FGA CLI version",
 	Long:  "Reports the FGA CLI version.",
-	RunE:  version,
-	Args:  cobra.NoArgs,
-}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(versionStr)
 
-func version(_ *cobra.Command, _ []string) error {
-	log.Printf("version `%s` build from `%s` on `%s` ", build.Version, build.Commit, build.Date)
-
-	return nil
+		return nil
+	},
+	Args: cobra.NoArgs,
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -4,7 +4,7 @@ package build
 
 var (
 
-	// Version is the build version of the app (e.g. v0.1.0)
+	// Version is the build version of the app (e.g. v0.1.0).
 	Version = "dev"
 
 	// Commit is the sha of the git commit the app was built against.

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,0 +1,15 @@
+// Package build provides build information that is linked into the application. Other
+// packages within this project can use this information in logs etc..
+package build
+
+var (
+
+	// Version is the build version of the app (e.g. v0.1.0)
+	Version = "dev"
+
+	// Commit is the sha of the git commit the app was built against.
+	Commit = "none"
+
+	// Date is the date when the app was built.
+	Date = "unknown"
+)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Adds the `fga version` command to the CLI.

## References
#70 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
