### PR TITLE
ci: add homebrew-tap release process to goreleaser manifest

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,10 +114,10 @@ brews:
       pull_request:
         enabled: true
     homepage: "https://openfga.dev/"
-    description: "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar."
+    description: "A cross-platform CLI to interact with an OpenFGA server."
     license: "Apache-2.0"
     folder: "Formula"
-    url_template: "https://github.com/openfga/openfga/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/openfga/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     download_strategy: CurlDownloadStrategy
 
     # update the head formula on each release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -107,6 +107,34 @@ docker_signs:
     - '${artifact}'
     - "--yes" # needed on cosign 2.0.0+
 
+brews:
+  - tap:
+      owner: openfga
+      name: homebrew-tap
+      pull_request:
+        enabled: true
+    homepage: "https://openfga.dev/"
+    description: "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar."
+    license: "Apache-2.0"
+    folder: "Formula"
+    url_template: "https://github.com/openfga/openfga/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    download_strategy: CurlDownloadStrategy
+
+    # update the head formula on each release
+    custom_block: |
+      head "https://github.com/openfga/cli.git", :branch => "main"
+    dependencies:
+      - name: go
+        type: optional
+      - name: git
+    install: |
+      bin.install "fga"
+      bash_completion.install "completions/fga.bash" => "goreleaser"
+      zsh_completion.install "completions/fga.zsh" => "_goreleaser"
+      fish_completion.install "completions/fga.fish"
+    test: |
+      system "#{bin}/fga version"
+
 archives:
   - rlcp: true
     files:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Adds a Homebrew tap release process to the goreleaser manifest.

## References
https://github.com/openfga/cli/issues/57

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
