### PR TITLE
chore: bumping openfga go-sdk version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,10 @@ require (
 	github.com/mattn/go-isatty v0.0.19
 	github.com/nwidger/jsoncolor v0.3.2
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/openfga/go-sdk v0.2.3-0.20230706193033-786d614eebbd
+	github.com/openfga/go-sdk v0.2.3-0.20230710203920-f6922b2d8c6d
 	github.com/openfga/openfga v1.2.0
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
 	go.buf.build/openfga/go/openfga/api v1.2.58
 	google.golang.org/protobuf v1.31.0
@@ -32,7 +33,6 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	go.buf.build/openfga/go/envoyproxy/protoc-gen-validate v1.2.8 // indirect
 	go.buf.build/openfga/go/grpc-ecosystem/grpc-gateway v1.2.51 // indirect

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/nwidger/jsoncolor v0.3.2 h1:rVJJlwAWDJShnbTYOQ5RM7yTA20INyKXlJ/fg4JMh
 github.com/nwidger/jsoncolor v0.3.2/go.mod h1:Cs34umxLbJvgBMnVNVqhji9BhoT/N/KinHqZptQ7cf4=
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
 github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/openfga/go-sdk v0.2.3-0.20230706193033-786d614eebbd h1:T/gza+TXR9Ld9FQIOzZhitmFQ+k7k6F8fUFG8NtrWBc=
-github.com/openfga/go-sdk v0.2.3-0.20230706193033-786d614eebbd/go.mod h1:ZB13O8GilPc0ITWssOszgxmz6CnIe8PQLZqbqAnx2IY=
+github.com/openfga/go-sdk v0.2.3-0.20230710203920-f6922b2d8c6d h1:xK4EfSnsB+U8zLyZ05h8V9omL6LF6Xh763bQphghuLk=
+github.com/openfga/go-sdk v0.2.3-0.20230710203920-f6922b2d8c6d/go.mod h1:ZB13O8GilPc0ITWssOszgxmz6CnIe8PQLZqbqAnx2IY=
 github.com/openfga/openfga v1.2.0 h1:7UAcw6OF69j/L5kmeTyqGRXXPwbycDHn4iyHIuxke1Y=
 github.com/openfga/openfga v1.2.0/go.mod h1:Nv/8zVfVCJCSpJhM8cf3RzZn88WXX0SaAxCMSIY5C1g=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=


### PR DESCRIPTION
## Description
chore of bumping openfga go-sdk version to fix issues associated with not respecting options and body

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
