### PR TITLE
fix: drop the `v` prefix for versioning

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,7 @@ builds:
       - darwin
     ldflags:
       - "-s -w"
-      - "-X github.com/openfga/cli/internal/build.Version=v{{ .Version }}"
+      - "-X github.com/openfga/cli/internal/build.Version={{ .Version }}"
       - "-X github.com/openfga/cli/internal/build.Commit={{.Commit}}"
       - "-X github.com/openfga/cli/internal/build.Date={{.Date}}"
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var versionStr = fmt.Sprintf("`%s` (commit: `%s`, date: `%s`)", build.Version, build.Commit, build.Date)
+var versionStr = fmt.Sprintf("v`%s` (commit: `%s`, date: `%s`)", build.Version, build.Commit, build.Date)
 
 // versionCmd is the entrypoint for the `fga version“ command.
 var versionCmd *cobra.Command = &cobra.Command{

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -2,9 +2,8 @@
 // packages within this project can use this information in logs etc..
 package build
 
-var (
-
-	// Version is the build version of the app (e.g. v0.1.0).
+const (
+	// Version is the build version of the app (e.g. 0.1.0).
 	Version = "dev"
 
 	// Commit is the sha of the git commit the app was built against.

--- a/lib/fga/fga.go
+++ b/lib/fga/fga.go
@@ -3,12 +3,13 @@ package fga
 import (
 	"net/url"
 
+	"github.com/openfga/cli/internal/build"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/openfga/go-sdk/credentials"
 )
 
-const userAgent = "openfga-cli/0.0.1"
+const userAgent = "openfga-cli/" + build.Version
 
 type ClientConfig struct {
 	ServerURL            string `json:"server_url,omitempty"`


### PR DESCRIPTION
makes the user agent consistent with the SDKs

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
