### PR TITLE
fix(tuple): change default max tuples per write in import

### DIFF
--- a/cmd/tuple/import.go
+++ b/cmd/tuple/import.go
@@ -29,10 +29,10 @@ import (
 )
 
 // MaxTuplesPerWrite Limit the tuples in a single batch.
-var MaxTuplesPerWrite = 20
+var MaxTuplesPerWrite = 1
 
 // MaxParallelRequests Limit the parallel writes to the API.
-var MaxParallelRequests = 4
+var MaxParallelRequests = 10
 
 type failedWriteResponse struct {
 	TupleKey client.ClientTupleKey `json:"tuple_key"`


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
- we are now defaulting to 1 for usuability (previously reimporting would fail for some new tuples because other tuples have already been imported)
- to work around the slower import, max parallel writes have been increased to 10

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- closes #103 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
