### PR TITLE
ci(goreleaser): drop pull request in goreleaser homebrew-tap

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -122,8 +122,6 @@ brews:
   - repository:
       owner: openfga
       name: homebrew-tap
-      pull_request:
-        enabled: true
     homepage: "https://openfga.dev/"
     description: "A cross-platform CLI to interact with an OpenFGA server."
     license: "Apache-2.0"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Drops the create PR feature for the homebrew-tap release process. This is what goreleaser does in their releases anyways..

https://github.com/goreleaser/goreleaser/blob/main/.goreleaser.yaml#L172-L194

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
