### PR TITLE
ci(goreleaser): set goreleaser homebrew skip_publish setting to 'auto'

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -128,7 +128,7 @@ brews:
     folder: "Formula"
     url_template: "https://github.com/openfga/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     download_strategy: CurlDownloadStrategy
-
+    skip_upload: "auto"
     # update the head formula on each release
     custom_block: |
       head "https://github.com/openfga/cli.git", :branch => "main"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
>  If set to auto, the release will not be uploaded to the homebrew tap in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1

This will prevent us from updating the head formula and publishing pre-release candidates to our homebrew tap.

## References
https://goreleaser.com/customization/homebrew/

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
