### PR TITLE
fix: set model id as nil if empty

### DIFF
--- a/internal/fga/fga.go
+++ b/internal/fga/fga.go
@@ -72,11 +72,16 @@ func (c ClientConfig) getClientConfig() (*client.ClientConfiguration, error) {
 		return nil, err //nolint:wrapcheck
 	}
 
+	var authorizationModelID *string
+	if c.AuthorizationModelID != "" {
+		authorizationModelID = openfga.PtrString(c.AuthorizationModelID)
+	}
+
 	return &client.ClientConfiguration{
 		ApiScheme:            apiURIParts.Scheme,
 		ApiHost:              apiURIParts.Host,
 		StoreId:              c.StoreID,
-		AuthorizationModelId: openfga.PtrString(c.AuthorizationModelID),
+		AuthorizationModelId: authorizationModelID,
 		Credentials:          c.getCredentials(),
 		UserAgent:            userAgent,
 	}, nil


### PR DESCRIPTION
## Description

This fixes `tuple import` without a specified Model ID.

## References

https://github.com/openfga/cli/pull/124
https://github.com/openfga/go-sdk/blob/f6922b2d8c6d9dc5532bd0cec67c55aac1924ff7/client/client.go#L432-L443 (should likely fix this condition in the sdk as well)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
