### PR TITLE
fix(config): use api-url instead of server-url to maintain consistency w/ sdks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ For any command that interacts with an OpenFGA server, these configuration value
 
 | Name                   | Flag                 | CLI                    | ~/.fga.yaml        |
 |------------------------|----------------------|------------------------|--------------------|
-| Server Url             | `--server-url`       | `FGA_SERVER_URL`       | `server-url`       |
+| API Url                | `--api-url`          | `FGA_API_URL`          | `api-url`          |
 | Shared Secret          | `--api-token`        | `FGA_API_TOKEN`        | `api-token`        |
 | Client ID              | `--client-id`        | `FGA_CLIENT_ID`        | `client-id`        |
 | Client Secret          | `--client-secret`    | `FGA_CLIENT_SECRET`    | `client-secret`    |
@@ -148,7 +148,7 @@ If you are authenticating with a shared secret, you should specify the API Token
 
 ```
 # Note: This example is for Auth0 FGA
-server-url: https://api.us1.fga.dev
+api-url: https://api.us1.fga.dev
 client-id: 4Zb..UYjaHreLKOJuU8
 client-secret: J3...2pBwiauD
 api-audience: https://api.us1.fga.dev/

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,7 +55,11 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.fga.yaml)")
 
+	// 'server-url' is deprecated in favor of 'api-url' for consistency with the SDKs,
+	// it is still kept here for backward compatibility
 	rootCmd.PersistentFlags().String("server-url", "http://localhost:8080", "OpenFGA API URI e.g. https://api.fga.example:8080") //nolint:lll
+	rootCmd.PersistentFlags().String("api-url", "http://localhost:8080", "OpenFGA API URI e.g. https://api.fga.example:8080")    //nolint:lll
+
 	rootCmd.PersistentFlags().String("api-token", "", "API Token. Will be sent in as a Bearer in the Authorization header")
 	rootCmd.PersistentFlags().String("api-token-issuer", "", "API Token Issuer. API responsible for issuing the API Token. Used in the Client Credentials flow") //nolint:lll
 	rootCmd.PersistentFlags().String("api-audience", "", "API Audience. Used when performing the Client Credentials flow")

--- a/internal/cmdutils/get-client-config.go
+++ b/internal/cmdutils/get-client-config.go
@@ -17,12 +17,24 @@ limitations under the License.
 package cmdutils
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/openfga/cli/internal/fga"
 	"github.com/spf13/cobra"
 )
 
 func GetClientConfig(cmd *cobra.Command) fga.ClientConfig {
-	serverURL, _ := cmd.Flags().GetString("server-url")
+	apiURL, _ := cmd.Flags().GetString("api-url")
+	if !cmd.Flags().Changed("api-url") && cmd.Flags().Changed("server-url") {
+		apiURL, _ = cmd.Flags().GetString("server-url")
+		_, _ = fmt.Fprintf(
+			os.Stderr,
+			"Using 'server-url' value of '%s'. Note that 'server-url' has been deprecated in favour of 'api-url' and may be removed in subsequent releases.\n", //nolint:lll
+			apiURL,
+		)
+	}
+
 	storeID, _ := cmd.Flags().GetString("store-id")
 	authorizationModelID, _ := cmd.Flags().GetString("model-id")
 	apiToken, _ := cmd.Flags().GetString("api-token")
@@ -32,7 +44,7 @@ func GetClientConfig(cmd *cobra.Command) fga.ClientConfig {
 	clientCredentialsClientSecret, _ := cmd.Flags().GetString("client-secret")
 
 	return fga.ClientConfig{
-		ServerURL:            serverURL,
+		ServerURL:            apiURL,
 		StoreID:              storeID,
 		AuthorizationModelID: authorizationModelID,
 		APIToken:             apiToken,

--- a/internal/fga/fga.go
+++ b/internal/fga/fga.go
@@ -29,7 +29,7 @@ import (
 var userAgent = "openfga-cli/" + build.Version
 
 type ClientConfig struct {
-	ServerURL            string `json:"server_url,omitempty"`
+	ServerURL            string `json:"api_url,omitempty"` //nolint:tagliatelle
 	StoreID              string `json:"store_id,omitempty"`
 	AuthorizationModelID string `json:"authorization_model_id,omitempty"`
 	APIToken             string `json:"api_token,omitempty"`


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

`server-url` is still read if `api-url` is not provided for backward compatibility

<img width="1331" alt="Screenshot 2023-09-18 at 9 53 03 AM" src="https://github.com/openfga/cli/assets/536147/0dcda1fa-b272-4f21-bc77-a5d224b1fd6a">

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
