### PR TITLE
fix: throw error when model input missing

### DIFF
--- a/internal/authorizationmodel/read-from-input.go
+++ b/internal/authorizationmodel/read-from-input.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openfga/cli/internal/clierrors"
 	"github.com/spf13/cobra"
 )
 
@@ -71,9 +72,7 @@ func ReadFromInputFileOrArg(
 
 	switch {
 	case fileName != "":
-		if err = ReadFromFile(fileName, input, format, storeName); err != nil {
-			return err
-		}
+		return ReadFromFile(fileName, input, format, storeName)
 	case len(args) > 0 && args[0] != "-":
 		*input = args[0]
 		// if the input format is set as the default, set it from the file extension (and default to fga)
@@ -81,7 +80,9 @@ func ReadFromInputFileOrArg(
 			*format = ModelFormatFGA
 		}
 	case !isOptional:
-		return cmd.Help() //nolint:wrapcheck
+		_ = cmd.Help() // print out the help message so users know what the command expects
+
+		return fmt.Errorf("%w", clierrors.ErrModelInputMissing)
 	}
 
 	return nil

--- a/internal/clierrors/clierrors.go
+++ b/internal/clierrors/clierrors.go
@@ -27,6 +27,7 @@ var (
 	ErrInvalidFormat              = errors.New("invalid format")
 	ErrStoreNotFound              = errors.New("store not found")
 	ErrAuthorizationModelNotFound = errors.New("authorization model not found")
+	ErrModelInputMissing          = errors.New("model input not provided")
 )
 
 func ValidationError(op string, details string) error {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

We still print out the help message so users can know what input we expect, but we also return an error and block the processing.

<img width="1059" alt="Screenshot 2023-09-18 at 5 13 36 PM" src="https://github.com/openfga/cli/assets/536147/3b46191d-6f23-40b1-9a06-9aee793d8b4f">


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
- Closes #145 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
