### PR TITLE
feat: create the --simple-json flag for tuple read

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ fga tuple **delete** <user> <relation> <object> --store-id=<store-id>
 If you want to delete all the tuples in a store, you can use the following code:
 
 ```
-fga tuple read | jq '[.tuples[] | { user: .key.user, relation: .key.relation, object: .key.object }]' > tuples.json
+fga tuple read --simple-json > tuples.json
 fga tuple delete --file tuples.json
 ```
 
@@ -670,6 +670,8 @@ fga tuple **read** [--user=<user>] [--relation=<relation>] [--object=<object>]  
 * `--user`: User
 * `--relation`: Relation
 * `--object`: Object
+* `--max-pages`: Max number of pages to get. (default 20)
+* `--simple-json`: Output simpler JSON version. (It can be used by write and delete commands)
 
 ###### Example
 `fga tuple read --store-id=01H0H015178Y2V4CX10C2KGHF4 --user user:anne --relation can_view --object document:roadmap`
@@ -689,11 +691,22 @@ fga tuple **read** [--user=<user>] [--relation=<relation>] [--object=<object>]  
   ]
 }
 ```
+###### Response (--simple-json)
+```json5
+[
+  {
+    "object": "document:roadmap",
+    "relation": "can_view",
+    "user": "user:anne"
+  }
+]
+```
+
 
 If you want to transform this output in a way that can be then imported using the `fga tuple import` you can run
 
 ```
-fga tuple read | jq '[.tuples[] | { user: .key.user, relation: .key.relation, object: .key.object }]' > tuples.json
+fga tuple read --simple-json > tuples.json
 fga tuple import --file tuples.json
 ```
 

--- a/cmd/tuple/read_test.go
+++ b/cmd/tuple/read_test.go
@@ -91,14 +91,24 @@ func TestReadEmpty(t *testing.T) {
 	}
 
 	expectedOutput := "{\"tuples\":[]}"
+	simpleOutput := "[]"
 
-	outputTxt, err := json.Marshal(output)
+	outputTxt, err := json.Marshal(output.complete)
 	if err != nil {
 		t.Error(err)
 	}
 
 	if string(outputTxt) != expectedOutput {
-		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+		t.Errorf("Expected output %v actual %v", expectedOutput, output.complete)
+	}
+
+	simpleTxt, err := json.Marshal(output.simple)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(simpleTxt) != simpleOutput {
+		t.Errorf("Expected output %v actual %v", simpleOutput, output.simple)
 	}
 }
 
@@ -153,15 +163,25 @@ func TestReadSinglePage(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedOutput := "{\"tuples\":[{\"key\":{\"object\":\"document:doc1\",\"relation\":\"reader\",\"user\":\"user:user1\"},\"timestamp\":\"2009-11-10T23:00:00Z\"}]}" //nolint:lll
+	expectedOutput := `{"tuples":[{"key":{"object":"document:doc1","relation":"reader","user":"user:user1"},"timestamp":"2009-11-10T23:00:00Z"}]}` //nolint:lll
+	simpleOutput := `[{"object":"document:doc1","relation":"reader","user":"user:user1"}]`                                                         //nolint:lll
 
-	outputTxt, err := json.Marshal(output)
+	outputTxt, err := json.Marshal(output.complete)
 	if err != nil {
 		t.Error(err)
 	}
 
 	if string(outputTxt) != expectedOutput {
-		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+		t.Errorf("Expected output %v actual %v", expectedOutput, output.complete)
+	}
+
+	simpleTxt, err := json.Marshal(output.simple)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(simpleTxt) != simpleOutput {
+		t.Errorf("Expected output %v actual %v", simpleOutput, output.simple)
 	}
 }
 
@@ -256,14 +276,24 @@ func TestReadMultiPages(t *testing.T) {
 	}
 
 	expectedOutput := `{"tuples":[{"key":{"object":"document:doc1","relation":"reader","user":"user:user1"},"timestamp":"2009-11-10T22:00:00Z"},{"key":{"object":"document:doc2","relation":"reader","user":"user:user1"},"timestamp":"2009-11-10T23:00:00Z"}]}` //nolint:lll
+	simpleOutput := `[{"object":"document:doc1","relation":"reader","user":"user:user1"},{"object":"document:doc2","relation":"reader","user":"user:user1"}]`                                                                                                    //nolint:lll
 
-	outputTxt, err := json.Marshal(output)
+	outputTxt, err := json.Marshal(output.complete)
 	if err != nil {
 		t.Error(err)
 	}
 
 	if string(outputTxt) != expectedOutput {
-		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+		t.Errorf("Expected output %v actual %v", expectedOutput, output.complete)
+	}
+
+	simpleTxt, err := json.Marshal(output.simple)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(simpleTxt) != simpleOutput {
+		t.Errorf("Expected output %v actual %v", simpleOutput, output.simple)
 	}
 }
 
@@ -318,14 +348,24 @@ func TestReadMultiPagesMaxLimit(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedOutput := "{\"tuples\":[{\"key\":{\"object\":\"document:doc1\",\"relation\":\"reader\",\"user\":\"user:user1\"},\"timestamp\":\"2009-11-10T23:00:00Z\"}]}" //nolint:lll
+	expectedOutput := `{"tuples":[{"key":{"object":"document:doc1","relation":"reader","user":"user:user1"},"timestamp":"2009-11-10T23:00:00Z"}]}` //nolint:lll
+	simpleOutput := `[{"object":"document:doc1","relation":"reader","user":"user:user1"}]`                                                         //nolint:lll
 
-	outputTxt, err := json.Marshal(output)
+	outputTxt, err := json.Marshal(output.complete)
 	if err != nil {
 		t.Error(err)
 	}
 
 	if string(outputTxt) != expectedOutput {
-		t.Errorf("Expected output %v actual %v", expectedOutput, output)
+		t.Errorf("Expected output %v actual %v", expectedOutput, output.complete)
+	}
+
+	simpleTxt, err := json.Marshal(output.simple)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(simpleTxt) != simpleOutput {
+		t.Errorf("Expected output %v actual %v", simpleOutput, output.simple)
 	}
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

aims to close #111 

I made the read function to return a "complete" version and a "simple" version of the JSON that can be imported by `tuple write` and `tuple delete` with the flag `--file`.

## Description

now if its informed the `--simple-json` flag the response is this:
```
./dist/fga tuple read --store-id 01HB3AZ6RAAGHJQ9HKXV9C89SE --simple-json
[
  {
    "object":"document:Z",
    "relation":"reader",
    "user":"user:gabriel"
  },
  {
    "object":"document:Z",
    "relation":"reader",
    "user":"user:anne"
  },
  {
    "object":"document:Z",
    "relation":"reader",
    "user":"user:jones"
  }
]
```

without the flag:
```
./dist/fga tuple read --store-id 01HB3AZ6RAAGHJQ9HKXV9C89SE              
{
  "tuples": [
    {
      "key": {
        "object":"document:Z",
        "relation":"reader",
        "user":"user:gabriel"
      },
      "timestamp":"2023-09-27T10:58:46.209655Z"
    },
    {
      "key": {
        "object":"document:Z",
        "relation":"reader",
        "user":"user:anne"
      },
      "timestamp":"2023-09-27T10:58:46.208397Z"
    },
    {
      "key": {
        "object":"document:Z",
        "relation":"reader",
        "user":"user:jones"
      },
      "timestamp":"2023-09-27T10:58:46.209576Z"
    }
  ]
}
```


now its possible to use like:
```
 ./dist/fga tuple read --store-id 01HB3AZ6RAAGHJQ9HKXV9C89SE --simple-json > tuple-simple.json
 ./dist/fga tuple delete --store-id 01HB3AZ6RAAGHJQ9HKXV9C89SE --file tuple-simple.json
{
  "successful": [
    {
      "object":"document:Z",
      "relation":"reader",
      "user":"user:gabriel"
    },
    {
      "object":"document:Z",
      "relation":"reader",
      "user":"user:anne"
    },
    {
      "object":"document:Z",
      "relation":"reader",
      "user":"user:jones"
    }
  ],
  "failed":null
}
```

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
