### PR TITLE
fix: prevent panic when no context is present

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,6 +46,7 @@ linters-settings:
           - github.com/spf13/pflag
           - github.com/spf13/viper
           - google.golang.org/protobuf/encoding/protojson
+          - google.golang.org/protobuf/types/known/structpb
           - gopkg.in/yaml.v3
       test:
         files:

--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -61,10 +61,10 @@ func validate(inputModel authorizationmodel.AuthzModel) validationResult {
 		return output
 	}
 
-	if model.Id != "" {
-		output.ID = model.Id
+	if model.GetId() != "" {
+		output.ID = model.GetId()
 
-		modelID, err := ulid.Parse(model.Id)
+		modelID, err := ulid.Parse(model.GetId())
 		if err != nil {
 			output.IsValid = false
 			errorString := "unable to parse id: invalid ulid format"

--- a/cmd/tuple/import.go
+++ b/cmd/tuple/import.go
@@ -79,7 +79,9 @@ func importTuples(
 	return &result, nil
 }
 
-func processWrites(writes []client.ClientWriteSingleResponse) ([]client.ClientWriteRequestTupleKey, []failedWriteResponse) {
+func processWrites(
+	writes []client.ClientWriteSingleResponse,
+) ([]client.ClientWriteRequestTupleKey, []failedWriteResponse) {
 	var (
 		successfulWrites []client.ClientWriteRequestTupleKey
 		failedWrites     []failedWriteResponse

--- a/internal/storetest/localtest.go
+++ b/internal/storetest/localtest.go
@@ -14,7 +14,7 @@ func RunSingleLocalCheckTest(
 	fgaServer *server.Server,
 	checkRequest *pb.CheckRequest,
 ) (*pb.CheckResponse, error) {
-	return fgaServer.Check(context.Background(), checkRequest)
+	return fgaServer.Check(context.Background(), checkRequest) //nolint:wrapcheck
 }
 
 func RunLocalCheckTest(
@@ -81,7 +81,7 @@ func RunSingleLocalListObjectsTest(
 	fgaServer *server.Server,
 	listObjectsRequest *pb.ListObjectsRequest,
 ) (*pb.ListObjectsResponse, error) {
-	return fgaServer.ListObjects(context.Background(), listObjectsRequest)
+	return fgaServer.ListObjects(context.Background(), listObjectsRequest) //nolint:wrapcheck
 }
 
 func RunLocalListObjectsTest(
@@ -131,7 +131,7 @@ func RunLocalListObjectsTest(
 			}
 
 			if response != nil {
-				result.Got = response.Objects
+				result.Got = response.GetObjects()
 				result.TestResult = result.IsPassing()
 			}
 		}

--- a/internal/storetest/localtest.go
+++ b/internal/storetest/localtest.go
@@ -37,7 +37,15 @@ func RunLocalCheckTest(
 			Expected: expectation,
 		}
 
-		ctx, err := structpb.NewStruct(*checkTest.Context)
+		var (
+			ctx *structpb.Struct
+			err error
+		)
+
+		if checkTest.Context != nil {
+			ctx, err = structpb.NewStruct(*checkTest.Context)
+		}
+
 		if err != nil {
 			result.Error = err
 		} else {
@@ -96,7 +104,15 @@ func RunLocalListObjectsTest(
 			Expected: expectation,
 		}
 
-		ctx, err := structpb.NewStruct(*listObjectsTest.Context)
+		var (
+			ctx *structpb.Struct
+			err error
+		)
+
+		if listObjectsTest.Context != nil {
+			ctx, err = structpb.NewStruct(*listObjectsTest.Context)
+		}
+
 		if err != nil {
 			result.Error = err
 		} else {

--- a/internal/storetest/remotetest.go
+++ b/internal/storetest/remotetest.go
@@ -97,7 +97,11 @@ func RunRemoteListObjectsTest(
 	return results
 }
 
-func RunRemoteTest(fgaClient *client.OpenFgaClient, test ModelTest, testTuples []client.ClientContextualTupleKey) TestResult {
+func RunRemoteTest(
+	fgaClient *client.OpenFgaClient,
+	test ModelTest,
+	testTuples []client.ClientContextualTupleKey,
+) TestResult {
 	checkResults := []ModelTestCheckSingleResult{}
 
 	for index := 0; index < len(test.Check); index++ {

--- a/internal/storetest/storedata.go
+++ b/internal/storetest/storedata.go
@@ -27,14 +27,14 @@ import (
 type ModelTestCheck struct {
 	User       string                  `json:"user"       yaml:"user"`
 	Object     string                  `json:"object"     yaml:"object"`
-	Context    *map[string]interface{} `json:"context"  yaml:"context"`
+	Context    *map[string]interface{} `json:"context"    yaml:"context"`
 	Assertions map[string]bool         `json:"assertions" yaml:"assertions"`
 }
 
 type ModelTestListObjects struct {
 	User       string                  `json:"user"       yaml:"user"`
 	Type       string                  `json:"type"       yaml:"type"`
-	Context    *map[string]interface{} `json:"context"  yaml:"context"`
+	Context    *map[string]interface{} `json:"context"    yaml:"context"`
 	Assertions map[string][]string     `json:"assertions" yaml:"assertions"`
 }
 

--- a/internal/storetest/testresult.go
+++ b/internal/storetest/testresult.go
@@ -2,6 +2,7 @@ package storetest
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/openfga/cli/internal/comparison"
@@ -82,7 +83,7 @@ func (result TestResult) FriendlyDisplay() string {
 
 				got := "N/A"
 				if checkResult.Got != nil {
-					got = fmt.Sprintf("%t", *checkResult.Got)
+					got = strconv.FormatBool(*checkResult.Got)
 				}
 
 				checkResultsOutput = fmt.Sprintf(
@@ -181,5 +182,5 @@ func (test TestResults) FriendlyDisplay() string {
 		friendlyResults = append(friendlyResults, test.Results[index].FriendlyDisplay())
 	}
 
-	return fmt.Sprintf("%v", strings.Join(friendlyResults, "\n---\n"))
+	return strings.Join(friendlyResults, "\n---\n")
 }


### PR DESCRIPTION
## Description

- fix: prevent panic when no context is present
- chore: make `make lint` happy

## References

https://github.com/openfga/cli/pull/169

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
