### PR TITLE
chore: establish and enforce a convention for import paths

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,6 @@ linters:
     - gochecknoinits
     - forbidigo
     - gochecknoglobals
-    - goimports
     # deprecated
     - exhaustivestruct
     - interfacer
@@ -70,5 +69,5 @@ linters-settings:
     lines: 120
     statements: 80
 
-  skip-dirs:
-    - mocks
+  goimports:
+    local-prefixes: "github.com/openfga/cli"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,7 @@ linters:
     - golint
     - nosnakecase
     - testpackage
+    - gci
 linters-settings:
   depguard:
     rules:

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,6 @@ $(GO_BIN)/gofumpt:
 	@echo "==> Installing gofumpt within "${GO_BIN}""
 	@go install -v mvdan.cc/gofumpt@latest
 
-$(GO_BIN)/gci:
-	@echo "==> Installing gci within "${GO_BIN}""
-	@go install -v github.com/daixiang0/gci@latest
-
 $(BUILD_DIR)/$(BINARY_NAME):
 	@echo "==> Building binary within ${BUILD_DIR}/${BINARY_NAME}"
 	go build -v -o ${BUILD_DIR}/${BINARY_NAME} main.go
@@ -62,4 +58,3 @@ audit: $(GO_BIN)/govulncheck
 format: $(GO_BIN)/gofumpt $(GO_BIN)/gci
 	@echo "==> Formatting project files"
 	gofumpt -w .
-	gci write -s standard -s default .

--- a/cmd/model/get.go
+++ b/cmd/model/get.go
@@ -21,14 +21,15 @@ import (
 	"fmt"
 	"os"
 
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/client"
+	"github.com/spf13/cobra"
+
 	"github.com/openfga/cli/internal/authorizationmodel"
 	"github.com/openfga/cli/internal/clierrors"
 	"github.com/openfga/cli/internal/cmdutils"
 	"github.com/openfga/cli/internal/fga"
 	"github.com/openfga/cli/internal/output"
-	openfga "github.com/openfga/go-sdk"
-	"github.com/openfga/go-sdk/client"
-	"github.com/spf13/cobra"
 )
 
 func getModel(clientConfig fga.ClientConfig, fgaClient client.SdkClient) (*openfga.ReadAuthorizationModelResponse,

--- a/cmd/model/get_test.go
+++ b/cmd/model/get_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/openfga/cli/internal/fga"
-	"github.com/openfga/cli/internal/mocks"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
+
+	"github.com/openfga/cli/internal/fga"
+	mock_client "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockGet = errors.New("mock error")

--- a/cmd/model/list.go
+++ b/cmd/model/list.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openfga/cli/internal/authorizationmodel"
-	"github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/authorizationmodel"
+	"github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 // MaxModelsPagesLength Limit the models so that we are not paginating indefinitely.

--- a/cmd/model/list_test.go
+++ b/cmd/model/list_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	mockclient "github.com/openfga/cli/internal/mocks"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
+
+	mockclient "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockList = errors.New("mock error")

--- a/cmd/model/test.go
+++ b/cmd/model/test.go
@@ -21,11 +21,12 @@ import (
 	"os"
 	"path"
 
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
 	"github.com/openfga/cli/internal/cmdutils"
 	"github.com/openfga/cli/internal/output"
 	"github.com/openfga/cli/internal/storetest"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // testCmd represents the test command.

--- a/cmd/model/transform.go
+++ b/cmd/model/transform.go
@@ -19,10 +19,11 @@ package model
 import (
 	"fmt"
 
-	"github.com/openfga/cli/internal/authorizationmodel"
-	"github.com/openfga/cli/internal/output"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/authorizationmodel"
+	"github.com/openfga/cli/internal/output"
 )
 
 // transformCmd represents the transform command.

--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -22,12 +22,13 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	pb "github.com/openfga/api/proto/openfga/v1"
-	"github.com/openfga/cli/internal/authorizationmodel"
-	"github.com/openfga/cli/internal/output"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/openfga/cli/internal/authorizationmodel"
+	"github.com/openfga/cli/internal/output"
 )
 
 type validationResult struct {

--- a/cmd/model/validate_test.go
+++ b/cmd/model/validate_test.go
@@ -4,8 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/openfga/cli/internal/authorizationmodel"
 	openfga "github.com/openfga/go-sdk"
+
+	"github.com/openfga/cli/internal/authorizationmodel"
 )
 
 func TestValidateCmdWithArgs(t *testing.T) {

--- a/cmd/model/write.go
+++ b/cmd/model/write.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openfga/cli/internal/authorizationmodel"
-	"github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/authorizationmodel"
+	"github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 func Write(

--- a/cmd/model/write_test.go
+++ b/cmd/model/write_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/openfga/go-sdk/client"
+
 	"github.com/openfga/cli/internal/authorizationmodel"
 	mockclient "github.com/openfga/cli/internal/mocks"
-	"github.com/openfga/go-sdk/client"
 )
 
 var errMockWrite = errors.New("mock error")

--- a/cmd/query/check.go
+++ b/cmd/query/check.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 
-	cmdutils2 "github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
+
+	cmdutils2 "github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 func check(

--- a/cmd/query/check_test.go
+++ b/cmd/query/check_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/openfga/cli/internal/mocks"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
+
+	mock_client "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockCheck = errors.New("mock error")

--- a/cmd/query/expand.go
+++ b/cmd/query/expand.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 func expand(fgaClient client.SdkClient, relation string, object string) (*client.ClientExpandResponse, error) {

--- a/cmd/query/expand_test.go
+++ b/cmd/query/expand_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/openfga/cli/internal/mocks"
 	"github.com/openfga/go-sdk/client"
+
+	mock_client "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockExpand = errors.New("mock error")

--- a/cmd/query/list-objects.go
+++ b/cmd/query/list-objects.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 
-	cmdutils2 "github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
+
+	cmdutils2 "github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 // listObjects in the internal function for calling SDK for list objects.

--- a/cmd/query/list-objects_test.go
+++ b/cmd/query/list-objects_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/openfga/cli/internal/mocks"
 	"github.com/openfga/go-sdk/client"
+
+	mock_client "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockListObjects = errors.New("mock error")

--- a/cmd/query/list-relations.go
+++ b/cmd/query/list-relations.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 	"strings"
 
-	cmdutils2 "github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/fga"
-	"github.com/openfga/cli/internal/output"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
+
+	cmdutils2 "github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/fga"
+	"github.com/openfga/cli/internal/output"
 )
 
 func getRelationsForType(

--- a/cmd/query/list-relations_test.go
+++ b/cmd/query/list-relations_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/openfga/cli/internal/fga"
-	"github.com/openfga/cli/internal/mocks"
 	"github.com/openfga/go-sdk/client"
+
+	"github.com/openfga/cli/internal/fga"
+	mock_client "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockGet = errors.New("mock get model error")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,13 +22,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/openfga/cli/cmd/model"
 	"github.com/openfga/cli/cmd/query"
 	"github.com/openfga/cli/cmd/store"
 	"github.com/openfga/cli/cmd/tuple"
 	"github.com/openfga/cli/internal/cmdutils"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var cfgFile string

--- a/cmd/store/create.go
+++ b/cmd/store/create.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/openfga/go-sdk/client"
+	"github.com/spf13/cobra"
+
 	"github.com/openfga/cli/cmd/model"
 	"github.com/openfga/cli/internal/authorizationmodel"
 	"github.com/openfga/cli/internal/cmdutils"
 	"github.com/openfga/cli/internal/fga"
 	"github.com/openfga/cli/internal/output"
-	"github.com/openfga/go-sdk/client"
-	"github.com/spf13/cobra"
 )
 
 type CreateStoreAndModelResponse struct {

--- a/cmd/store/create_test.go
+++ b/cmd/store/create_test.go
@@ -7,8 +7,9 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/openfga/cli/internal/mocks"
 	"github.com/openfga/go-sdk/client"
+
+	mock_client "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockCreate = errors.New("mock error")

--- a/cmd/store/delete.go
+++ b/cmd/store/delete.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/openfga/cli/internal/cmdutils"
 	"github.com/openfga/cli/internal/confirmation"
 	"github.com/openfga/cli/internal/output"
-	"github.com/spf13/cobra"
 )
 
 // deleteCmd represents the delete command.

--- a/cmd/store/get.go
+++ b/cmd/store/get.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/openfga/go-sdk/client"
+	"github.com/spf13/cobra"
+
 	"github.com/openfga/cli/internal/cmdutils"
 	"github.com/openfga/cli/internal/fga"
 	"github.com/openfga/cli/internal/output"
-	"github.com/openfga/go-sdk/client"
-	"github.com/spf13/cobra"
 )
 
 func getStore(clientConfig fga.ClientConfig, fgaClient client.SdkClient) (*client.ClientGetStoreResponse, error) {

--- a/cmd/store/get_test.go
+++ b/cmd/store/get_test.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/openfga/cli/internal/fga"
-	"github.com/openfga/cli/internal/mocks"
 	"github.com/openfga/go-sdk/client"
+
+	"github.com/openfga/cli/internal/fga"
+	mock_client "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockGet = errors.New("mock error")

--- a/cmd/store/list.go
+++ b/cmd/store/list.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 // MaxStoresPagesLength Limit the pages of stores so that we are not paginating indefinitely.

--- a/cmd/store/list_test.go
+++ b/cmd/store/list_test.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	mockclient "github.com/openfga/cli/internal/mocks"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
+
+	mockclient "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockListStores = errors.New("mock error")

--- a/cmd/tuple/changes.go
+++ b/cmd/tuple/changes.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 // MaxReadChangesPagesLength Limit the changes so that we are not paginating indefinitely.

--- a/cmd/tuple/changes_test.go
+++ b/cmd/tuple/changes_test.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/openfga/cli/internal/mocks"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
+
+	mock_client "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockReadChanges = errors.New("mock error")

--- a/cmd/tuple/delete.go
+++ b/cmd/tuple/delete.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 // deleteCmd represents the delete command.

--- a/cmd/tuple/import.go
+++ b/cmd/tuple/import.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 // MaxTuplesPerWrite Limit the tuples in a single batch.

--- a/cmd/tuple/read.go
+++ b/cmd/tuple/read.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 // MaxReadPagesLength Limit the tuples so that we are not paginating indefinitely.

--- a/cmd/tuple/read_test.go
+++ b/cmd/tuple/read_test.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/openfga/cli/internal/mocks"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
+
+	mock_client "github.com/openfga/cli/internal/mocks"
 )
 
 var errMockRead = errors.New("mock error")

--- a/cmd/tuple/write.go
+++ b/cmd/tuple/write.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openfga/cli/internal/cmdutils"
-	"github.com/openfga/cli/internal/output"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
 )
 
 // writeCmd represents the write command.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,8 +19,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/openfga/cli/internal/build"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/build"
 )
 
 var versionStr = fmt.Sprintf("v`%s` (commit: `%s`, date: `%s`)", build.Version, build.Commit, build.Date)

--- a/internal/authorizationmodel/model.go
+++ b/internal/authorizationmodel/model.go
@@ -23,10 +23,11 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	pb "github.com/openfga/api/proto/openfga/v1"
-	"github.com/openfga/cli/internal/slices"
 	openfga "github.com/openfga/go-sdk"
 	language "github.com/openfga/language/pkg/go/transformer"
 	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/openfga/cli/internal/slices"
 )
 
 func getCreatedAtFromModelID(id string) (*time.Time, error) {

--- a/internal/authorizationmodel/model_test.go
+++ b/internal/authorizationmodel/model_test.go
@@ -3,9 +3,10 @@ package authorizationmodel_test
 import (
 	"testing"
 
-	"github.com/openfga/cli/internal/authorizationmodel"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/openfga/pkg/typesystem"
+
+	"github.com/openfga/cli/internal/authorizationmodel"
 )
 
 const (

--- a/internal/authorizationmodel/read-from-input.go
+++ b/internal/authorizationmodel/read-from-input.go
@@ -23,8 +23,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openfga/cli/internal/clierrors"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/clierrors"
 )
 
 func ReadFromFile(

--- a/internal/cmdutils/get-client-config.go
+++ b/internal/cmdutils/get-client-config.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openfga/cli/internal/fga"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/fga"
 )
 
 func GetClientConfig(cmd *cobra.Command) fga.ClientConfig {

--- a/internal/cmdutils/get-contextual-tuples.go
+++ b/internal/cmdutils/get-contextual-tuples.go
@@ -19,9 +19,10 @@ package cmdutils
 import (
 	"strings"
 
-	"github.com/openfga/cli/internal/clierrors"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/clierrors"
 )
 
 func ParseContextualTuplesInner(contextualTuplesArray []string) ([]client.ClientContextualTupleKey, error) {

--- a/internal/cmdutils/get-contextual-tuples_test.go
+++ b/internal/cmdutils/get-contextual-tuples_test.go
@@ -19,8 +19,9 @@ package cmdutils_test
 import (
 	"testing"
 
-	"github.com/openfga/cli/internal/cmdutils"
 	"github.com/openfga/go-sdk/client"
+
+	"github.com/openfga/cli/internal/cmdutils"
 )
 
 type tupleTestPassing struct {

--- a/internal/fga/fga.go
+++ b/internal/fga/fga.go
@@ -18,9 +18,10 @@ limitations under the License.
 package fga
 
 import (
-	"github.com/openfga/cli/internal/build"
 	"github.com/openfga/go-sdk/client"
 	"github.com/openfga/go-sdk/credentials"
+
+	"github.com/openfga/cli/internal/build"
 )
 
 var userAgent = "openfga-cli/" + build.Version

--- a/internal/storetest/localstore.go
+++ b/internal/storetest/localstore.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	pb "github.com/openfga/api/proto/openfga/v1"
-	"github.com/openfga/cli/internal/authorizationmodel"
 	"github.com/openfga/go-sdk/client"
 	"github.com/openfga/openfga/pkg/server"
 	"github.com/openfga/openfga/pkg/storage/memory"
+
+	"github.com/openfga/cli/internal/authorizationmodel"
 )
 
 const writeMaxChunkSize = 40

--- a/internal/storetest/localtest.go
+++ b/internal/storetest/localtest.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	pb "github.com/openfga/api/proto/openfga/v1"
-	"github.com/openfga/cli/internal/authorizationmodel"
 	"github.com/openfga/go-sdk/client"
 	"github.com/openfga/openfga/pkg/server"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/openfga/cli/internal/authorizationmodel"
 )
 
 func RunSingleLocalCheckTest(

--- a/internal/storetest/storedata.go
+++ b/internal/storetest/storedata.go
@@ -20,8 +20,9 @@ package storetest
 import (
 	"path"
 
-	"github.com/openfga/cli/internal/authorizationmodel"
 	"github.com/openfga/go-sdk/client"
+
+	"github.com/openfga/cli/internal/authorizationmodel"
 )
 
 type ModelTestCheck struct {

--- a/internal/storetest/testresult.go
+++ b/internal/storetest/testresult.go
@@ -5,8 +5,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openfga/cli/internal/comparison"
 	"github.com/openfga/go-sdk/client"
+
+	"github.com/openfga/cli/internal/comparison"
 )
 
 type ModelTestCheckSingleResult struct {

--- a/internal/storetest/tests.go
+++ b/internal/storetest/tests.go
@@ -1,9 +1,10 @@
 package storetest
 
 import (
-	"github.com/openfga/cli/internal/authorizationmodel"
 	"github.com/openfga/go-sdk/client"
 	"github.com/openfga/openfga/pkg/server"
+
+	"github.com/openfga/cli/internal/authorizationmodel"
 )
 
 type ModelTestOptions struct {


### PR DESCRIPTION
## Description

The main focus of this PR is to establish and enforce a convention for grouping import paths. This is easily achieved by introducing an extra check within the `golangci-lint` config that will:

- Move all imports into a single declaration
- Groups stdlib imports
- Groups 3rd party pkg imports
- Groups current project imports

**Why?** 

Grouping import paths is important for several reasons:

- Improved readability
- Makes the code more predictable
- Easier to identify and manage dependencies
- Reduce cognitive load

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- Similar to https://github.com/openfga/openfga/pull/1253

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
