### PR TITLE
feat(test): support referenvcing a tuple_file instead of tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ The tests file should be in yaml and have the following format:
 ---
 name: Store Name # store name, optional
 # model_file: ./model.fga # a global model that would apply to all tests, optional
-# model can be used instead of model-file, optional
+# model can be used instead of model_file, optional
 model: |
   model
     schema 1.1
@@ -453,6 +453,7 @@ model: |
       define can_write: owner or can_write from parent
       define can_share: owner
 
+# tuple_file: ./tuples.yaml # global tuples that would apply to all tests, optional
 tuples: # global tuples that would apply to all tests, optional
   - user: folder:1
     relation: parent
@@ -460,6 +461,7 @@ tuples: # global tuples that would apply to all tests, optional
 tests: # required
   - name: test-1
     description: testing that the model works # optional
+    # tuple_file: ./tuples.json # tuples that would apply per test
     tuples:
       - user: user:anne
         relation: owner

--- a/example/folder-document-access_tuples.json
+++ b/example/folder-document-access_tuples.json
@@ -1,0 +1,17 @@
+[
+    {
+        "user": "user:anne",
+        "relation": "owner",
+        "object": "folder:product"
+    },
+    {
+        "user": "folder:product",
+        "relation": "parent",
+        "object": "folder:product-2021"
+    },
+    {
+        "user": "user:beth",
+        "relation": "viewer",
+        "object": "folder:product-2021"
+    }
+]

--- a/example/model.fga.yaml
+++ b/example/model.fga.yaml
@@ -6,26 +6,28 @@ model_file: ./model.fga # a global model that would apply to all tests
 #    schema 1.1
 #  type user
 #  ...
-tuples: # global tuples that would apply to all tests
-  - user: folder:5
-    relation: parent
-    object: folder:product-2021
-  - user: folder:product-2021
-    relation: parent
-    object: folder:product-2021Q1
+tuple_file: ./model_tuples.yaml  # global tuples that would apply to all tests
+# tuples can also be used instead of tuple_file
+#tuples:
+#   - user: folder:5
+#     relation: parent
+#     object: folder:product-2021
+#   - user: folder:product-2021
+#     relation: parent
+#     object: folder:product-2021Q1
 tests:
   - name: "folder-document-access"
     description: ""
-    tuples: # tuples in tests are appended to the global tuples and do not replace them
-      - user: user:anne
-        relation: owner
-        object: folder:product
-      - user: folder:product
-        relation: parent
-        object: folder:product-2021
-      - user: user:beth
-        relation: viewer
-        object: folder:product-2021
+     # tuples in tests are appended to the global tuples and do not replace them
+    tuple_file: ./folder-document-access_tuples.json
+    # tuples can also be used instead of tuple_file
+    #tuples:
+    #   - user: folder:5
+    #     relation: parent
+    #     object: folder:product-2021
+    #   - user: folder:product-2021
+    #     relation: parent
+    #     object: folder:product-2021Q1
     check: # Each check test is made of: a user, an object and the expected result for one or more relations
       - user: user:anne
         object: folder:product-2021

--- a/example/model_tuples.yaml
+++ b/example/model_tuples.yaml
@@ -1,0 +1,6 @@
+- user: folder:5
+  relation: parent
+  object: folder:product-2021
+- user: folder:product-2021
+  relation: parent
+  object: folder:product-2021Q1

--- a/internal/storetest/localstore.go
+++ b/internal/storetest/localstore.go
@@ -70,8 +70,8 @@ func initLocalStore(
 	return &storeID, modelID, nil
 }
 
-func getLocalServerAndModel(
-	storeData StoreData,
+func getLocalServerModelAndTuples(
+	storeData *StoreData,
 	basePath string,
 ) (*server.Server, *authorizationmodel.AuthzModel, error) {
 	var fgaServer *server.Server
@@ -79,6 +79,11 @@ func getLocalServerAndModel(
 	var authModel *authorizationmodel.AuthzModel
 
 	format, err := storeData.LoadModel(basePath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = storeData.LoadTuples(basePath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/storetest/storedata.go
+++ b/internal/storetest/storedata.go
@@ -18,9 +18,16 @@ limitations under the License.
 package storetest
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
 	"path"
 
 	"github.com/openfga/go-sdk/client"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/openfga/cli/internal/authorizationmodel"
 )
@@ -43,6 +50,7 @@ type ModelTest struct {
 	Name        string                            `json:"name"         yaml:"name"`
 	Description string                            `json:"description"  yaml:"description"`
 	Tuples      []client.ClientContextualTupleKey `json:"tuples"       yaml:"tuples"`
+	TupleFile   string                            `json:"tuple_file"   yaml:"tuple_file"` //nolint:tagliatelle
 	Check       []ModelTestCheck                  `json:"check"        yaml:"check"`
 	ListObjects []ModelTestListObjects            `json:"list_objects" yaml:"list_objects"` //nolint:tagliatelle
 }
@@ -52,6 +60,7 @@ type StoreData struct {
 	Model     string                            `json:"model"      yaml:"model"`
 	ModelFile string                            `json:"model_file" yaml:"model_file"` //nolint:tagliatelle
 	Tuples    []client.ClientContextualTupleKey `json:"tuples"     yaml:"tuples"`
+	TupleFile string                            `json:"tuple_file" yaml:"tuple_file"` //nolint:tagliatelle
 	Tests     []ModelTest                       `json:"tests"      yaml:"tests"`
 }
 
@@ -81,4 +90,75 @@ func (storeData *StoreData) LoadModel(basePath string) (authorizationmodel.Model
 	}
 
 	return format, nil
+}
+
+func (storeData *StoreData) LoadTuples(basePath string) error {
+	var errs error
+
+	if storeData.TupleFile != "" {
+		tuples, err := readTupleFile(path.Join(basePath, storeData.TupleFile))
+		if err != nil {
+			errs = fmt.Errorf("failed to process global tuple %s file due to %w", storeData.TupleFile, err)
+		} else {
+			storeData.Tuples = tuples
+		}
+	}
+
+	for index := 0; index < len(storeData.Tests); index++ {
+		test := storeData.Tests[index]
+		if test.TupleFile == "" {
+			continue
+		}
+
+		tuples, err := readTupleFile(path.Join(basePath, test.TupleFile))
+		if err != nil {
+			errs = errors.Join(
+				errs,
+				fmt.Errorf("failed to process tuple file %s for test %s due to %w", test.TupleFile, test.Name, err),
+			)
+		} else {
+			storeData.Tests[index].Tuples = tuples
+		}
+	}
+
+	if errs != nil {
+		return errors.Join(errors.New("failed to process one or more tuple files"), errs) //nolint:goerr113
+	}
+
+	return nil
+}
+
+func readTupleFile(tuplePath string) ([]client.ClientContextualTupleKey, error) {
+	var tuples []client.ClientContextualTupleKey
+
+	tupleFile, err := os.Open(tuplePath)
+	if err != nil {
+		return nil, err //nolint:wrapcheck
+	}
+	defer tupleFile.Close()
+
+	switch path.Ext(tuplePath) {
+	case ".json":
+		contents, err := io.ReadAll(tupleFile)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+
+		err = json.Unmarshal(contents, &tuples)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+	case ".yaml", ".yml":
+		decoder := yaml.NewDecoder(tupleFile)
+		decoder.KnownFields(true)
+
+		err = decoder.Decode(&tuples)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+	default:
+		return nil, fmt.Errorf("unsupported file format %s", path.Ext(tuplePath)) //nolint:goerr113
+	}
+
+	return tuples, nil
 }

--- a/internal/storetest/tests.go
+++ b/internal/storetest/tests.go
@@ -36,7 +36,7 @@ func RunTests(
 ) (TestResults, error) {
 	test := TestResults{}
 
-	fgaServer, authModel, err := getLocalServerAndModel(storeData, basePath)
+	fgaServer, authModel, err := getLocalServerModelAndTuples(&storeData, basePath)
 	if err != nil {
 		return test, err
 	}


### PR DESCRIPTION
## Description

Adds support for using `tuple_file` instead of `tuples` in a test file. The file can be either a `yaml` or `json` syntax. All tuple files are loaded upfront before running tests so that we can ensure that the test run will be functional and all errors are collated and presented to the user like below.

```
fga model test --tests ./example/model.fga.yaml
Error: error running tests due to failed to process one or more tuple files
failed to process global tuple ./model_tuples.yaml file due to yaml: line 7: could not find expected ':'
failed to process tuple file ./folder-document-access_tuple.json for test folder-document-access due to open example/folder-document-access_tuple.json: no such file or directory
exit status 1
```

The `model.fga.yaml` example has been updated to show this and also demonstrate the two file types that are supported.

## References

Closes #179

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
