### PR TITLE
feat(changes): accept continuation token as a command line argument, display last token

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ type document
 | [Write Relationship Tuples](#write-relationship-tuples)                           | `write`   | `--store-id`, `--model-id`           | `fga tuple write user:anne can_view document:roadmap --store-id=01H0H015178Y2V4CX10C2KGHF4`        |
 | [Delete Relationship Tuples](#delete-relationship-tuples)                         | `delete`  | `--store-id`, `--model-id`           | `fga tuple delete user:anne can_view document:roadmap --store-id=01H0H015178Y2V4CX10C2KGHF4`                                                          |
 | [Read Relationship Tuples](#read-relationship-tuples)                             | `read`    | `--store-id`, `--model-id`           | `fga tuple read --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1`                      |
-| [Read Relationship Tuple Changes (Watch)](#read-relationship-tuple-changes-watch) | `changes` | `--store-id`, `--model-id`           | `fga tuple changes --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1`                   |
+| [Read Relationship Tuple Changes (Watch)](#read-relationship-tuple-changes-watch) | `changes` | `--store-id`, `--type`, `--continuation-token`,           | `fga tuple changes --store-id=01H0H015178Y2V4CX10C2KGHF4 --type=document --continuation-token=M3w=`                   |
 | [Import Relationship Tuples](#import-relationship-tuples)                        | `import`  | `--store-id`, `--model-id`, `--file` | `fga tuple import --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1 --file tuples.json` |
 
 ##### Write Relationship Tuples
@@ -719,11 +719,12 @@ fga tuple **changes** --type <type> --store-id=<store-id>
 
 ###### Parameters
 * `--store-id`: Specifies the store id
-* `--type`: restrict to a specific type (optional)
+* `--type`: Restrict to a specific type (optional)
 * `--max-pages`: Max number of pages to retrieve (default: 20)
+* `--continuation-token`: Continuation token to start changes from
 
 ###### Example
-`fga tuple changes --store-id=01H0H015178Y2V4CX10C2KGHF4 --type document`
+`fga tuple changes --store-id=01H0H015178Y2V4CX10C2KGHF4 --type=document --continuation-token=M3w=`
 
 ###### Response
 ```json5
@@ -738,7 +739,8 @@ fga tuple **changes** --type <type> --store-id=<store-id>
         "user": "user:anne"
       }
     }
-  ]
+  ],
+  "continuation_token":"NHw="
 }
 ```
 

--- a/cmd/tuple/changes_test.go
+++ b/cmd/tuple/changes_test.go
@@ -44,7 +44,7 @@ func TestReadChangesError(t *testing.T) {
 
 	mockFgaClient.EXPECT().ReadChanges(context.Background()).Return(mockBody)
 
-	_, err := readChanges(mockFgaClient, 5, "document")
+	_, err := readChanges(mockFgaClient, 5, "document", "")
 	if err == nil {
 		t.Error("Expect error but there is none")
 	}
@@ -82,12 +82,12 @@ func TestReadChangesEmpty(t *testing.T) {
 
 	mockFgaClient.EXPECT().ReadChanges(context.Background()).Return(mockBody)
 
-	output, err := readChanges(mockFgaClient, 5, "document")
+	output, err := readChanges(mockFgaClient, 5, "document", "")
 	if err != nil {
 		t.Error(err)
 	}
 
-	expectedOutput := `{"changes":[]}`
+	expectedOutput := `{"changes":[],"continuation_token":""}`
 
 	outputTxt, err := json.Marshal(output)
 	if err != nil {
@@ -146,12 +146,12 @@ func TestReadChangesSinglePage(t *testing.T) {
 
 	mockFgaClient.EXPECT().ReadChanges(context.Background()).Return(mockBody)
 
-	output, err := readChanges(mockFgaClient, 5, "document")
+	output, err := readChanges(mockFgaClient, 5, "document", "")
 	if err != nil {
 		t.Error(err)
 	}
 
-	expectedOutput := `{"changes":[{"operation":"TUPLE_OPERATION_WRITE","timestamp":"2009-11-10T23:00:00Z","tuple_key":{"object":"document:doc1","relation":"reader","user":"user:user1"}}]}` //nolint:lll
+	expectedOutput := `{"changes":[{"operation":"TUPLE_OPERATION_WRITE","timestamp":"2009-11-10T23:00:00Z","tuple_key":{"object":"document:doc1","relation":"reader","user":"user:user1"}}],"continuation_token":""}` //nolint:lll
 
 	outputTxt, err := json.Marshal(output)
 	if err != nil {
@@ -246,12 +246,12 @@ func TestReadChangesMultiPages(t *testing.T) {
 		mockFgaClient.EXPECT().ReadChanges(context.Background()).Return(mockBody2),
 	)
 
-	output, err := readChanges(mockFgaClient, 5, "document")
+	output, err := readChanges(mockFgaClient, 5, "document", "")
 	if err != nil {
 		t.Error(err)
 	}
 
-	expectedOutput := `{"changes":[{"operation":"TUPLE_OPERATION_WRITE","timestamp":"2009-11-10T22:00:00Z","tuple_key":{"object":"document:doc1","relation":"reader","user":"user:user1"}},{"operation":"TUPLE_OPERATION_DELETE","timestamp":"2009-11-10T23:00:00Z","tuple_key":{"object":"document:doc1","relation":"reader","user":"user:user1"}}]}` //nolint:lll
+	expectedOutput := `{"changes":[{"operation":"TUPLE_OPERATION_WRITE","timestamp":"2009-11-10T22:00:00Z","tuple_key":{"object":"document:doc1","relation":"reader","user":"user:user1"}},{"operation":"TUPLE_OPERATION_DELETE","timestamp":"2009-11-10T23:00:00Z","tuple_key":{"object":"document:doc1","relation":"reader","user":"user:user1"}}],"continuation_token":"01GXSA8YR785C4FYS3C0RTG7B2"}` //nolint:lll
 
 	outputTxt, err := json.Marshal(output)
 	if err != nil {
@@ -310,12 +310,12 @@ func TestReadChangesMultiPagesLimit(t *testing.T) {
 
 	mockFgaClient.EXPECT().ReadChanges(context.Background()).Return(mockBody)
 
-	output, err := readChanges(mockFgaClient, 1, "document")
+	output, err := readChanges(mockFgaClient, 1, "document", "")
 	if err != nil {
 		t.Error(err)
 	}
 
-	expectedOutput := `{"changes":[{"operation":"TUPLE_OPERATION_WRITE","timestamp":"2009-11-10T23:00:00Z","tuple_key":{"object":"document:doc1","relation":"reader","user":"user:user1"}}]}` //nolint:lll
+	expectedOutput := `{"changes":[{"operation":"TUPLE_OPERATION_WRITE","timestamp":"2009-11-10T23:00:00Z","tuple_key":{"object":"document:doc1","relation":"reader","user":"user:user1"}}],"continuation_token":"01GXSA8YR785C4FYS3C0RTG7B2"}` //nolint:lll
 
 	outputTxt, err := json.Marshal(output)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

This PR adds a `--continuation-token` flag to the `fga tuple changes` command to allow passing a continuation token that was provided by the FGA server. It also now logs the last retrieved continuation token alongside the changes output

<details>
<summary>Sample output</summary>

```
fga tuple changes --store-id 01HKMFHMD00Z298PFBT848K1N0
{
  "changes": [
    {
      "operation":"TUPLE_OPERATION_WRITE",
      "timestamp":"2024-01-08T12:08:01.312914916Z",
      "tuple_key": {
        "object":"group:foo",
        "relation":"member",
        "user":"user:anne"
      }
    },
    {
      "operation":"TUPLE_OPERATION_DELETE",
      "timestamp":"2024-01-08T12:10:21.524092718Z",
      "tuple_key": {
        "object":"group:foo",
        "relation":"member",
        "user":"user:anne"
      }
    },
    {
      "operation":"TUPLE_OPERATION_WRITE",
      "timestamp":"2024-01-08T12:10:29.012827054Z",
      "tuple_key": {
        "object":"group:bar",
        "relation":"member",
        "user":"user:bob"
      }
    }
  ],
  "continuation_token":"M3w="
}
fga tuple changes --store-id 01HKMFHMD00Z298PFBT848K1N0 --continuation-token M3w=
{
  "changes": [],
  "continuation_token":"M3w="
}
fga tuple changes --store-id 01HKMFHMD00Z298PFBT848K1N0 --continuation-token M3w=
{
  "changes": [
    {
      "operation":"TUPLE_OPERATION_DELETE",
      "timestamp":"2024-01-08T14:29:14.638373214Z",
      "tuple_key": {
        "object":"group:bar",
        "relation":"member",
        "user":"user:bob"
      }
    }
  ],
  "continuation_token":"NHw="
}
```

</details>

## References

Closes #98 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
