### PR TITLE
docs: add scoop install via windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Alpine Linux:
 sudo apk add --allow-untrusted ./fga_<version>_linux_<arch>.apk
 ```
 
+### Windows
+
+via [Scoop](https://scoop.sh/)
+```shell
+scoop install openfga
+```
+
 ### Docker
 ```shell
 docker pull openfga/cli; docker run -it openfga/cli


### PR DESCRIPTION
Docs change for installing OpenFGA cli on Windows via Scoop. 

Scoop manifest was added via: https://github.com/ScoopInstaller/Main/pull/5331

Requested by @aaguiarz : https://github.com/ScoopInstaller/Main/issues/5330#issuecomment-1890778934
