### PR TITLE
feat: oauth2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ go.work
 
 # IDEs
 .idea/
+*.iml
 
 # Built files
 dist/

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ For any command that interacts with an OpenFGA server, these configuration value
 | Shared Secret          | `--api-token`        | `FGA_API_TOKEN`        | `api-token`        |
 | Client ID              | `--client-id`        | `FGA_CLIENT_ID`        | `client-id`        |
 | Client Secret          | `--client-secret`    | `FGA_CLIENT_SECRET`    | `client-secret`    |
+| Scopes                 | `--api-scopes`       | `FGA_API_SCOPES`       | `api-scopes`       |
 | Token Issuer           | `--api-token-issuer` | `FGA_API_TOKEN_ISSUER` | `api-token-issuer` |
 | Token Audience         | `--api-audience`     | `FGA_API_AUDIENCE`     | `api-audience`     |
 | Store ID               | `--store-id`         | `FGA_STORE_ID`         | `store-id`         |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,12 +64,12 @@ func init() {
 	rootCmd.PersistentFlags().String("api-token", "", "API Token. Will be sent in as a Bearer in the Authorization header")
 	rootCmd.PersistentFlags().String("api-token-issuer", "", "API Token Issuer. API responsible for issuing the API Token. Used in the Client Credentials flow") //nolint:lll
 	rootCmd.PersistentFlags().String("api-audience", "", "API Audience. Used when performing the Client Credentials flow")
-	rootCmd.PersistentFlags().String("client-id", "", "Client ID. Sent to the Token Issuer during the Client Credentials flow")         //nolint:lll
-	rootCmd.PersistentFlags().String("client-secret", "", "Client Secret. Sent to the Token Issuer during the Client Credentials flow") //nolint:lll
+	rootCmd.PersistentFlags().String("client-id", "", "Client ID. Sent to the Token Issuer during the Client Credentials flow")                            //nolint:lll
+	rootCmd.PersistentFlags().String("client-secret", "", "Client Secret. Sent to the Token Issuer during the Client Credentials flow")                    //nolint:lll
+	rootCmd.PersistentFlags().StringArray("api-scopes", []string{}, "API Scopes (repeat option for multiple values). Used in the Client Credentials flow") //nolint:lll
 
 	rootCmd.MarkFlagsRequiredTogether(
 		"api-token-issuer",
-		"api-audience",
 		"client-id",
 		"client-secret",
 	)

--- a/internal/cmdutils/get-client-config.go
+++ b/internal/cmdutils/get-client-config.go
@@ -54,6 +54,6 @@ func GetClientConfig(cmd *cobra.Command) fga.ClientConfig {
 		APIAudience:          clientCredentialsAPIAudience,
 		ClientID:             clientCredentialsClientID,
 		ClientSecret:         clientCredentialsClientSecret,
-		ApiScopes:            clientCredentialsScopes,
+		APIScopes:            clientCredentialsScopes,
 	}
 }

--- a/internal/cmdutils/get-client-config.go
+++ b/internal/cmdutils/get-client-config.go
@@ -43,6 +43,7 @@ func GetClientConfig(cmd *cobra.Command) fga.ClientConfig {
 	clientCredentialsAPIAudience, _ := cmd.Flags().GetString("api-audience")
 	clientCredentialsClientID, _ := cmd.Flags().GetString("client-id")
 	clientCredentialsClientSecret, _ := cmd.Flags().GetString("client-secret")
+	clientCredentialsScopes, _ := cmd.Flags().GetStringArray("api-scopes")
 
 	return fga.ClientConfig{
 		ApiUrl:               apiURL,
@@ -53,5 +54,6 @@ func GetClientConfig(cmd *cobra.Command) fga.ClientConfig {
 		APIAudience:          clientCredentialsAPIAudience,
 		ClientID:             clientCredentialsClientID,
 		ClientSecret:         clientCredentialsClientSecret,
+		ApiScopes:            clientCredentialsScopes,
 	}
 }

--- a/internal/fga/fga.go
+++ b/internal/fga/fga.go
@@ -20,6 +20,7 @@ package fga
 import (
 	"github.com/openfga/go-sdk/client"
 	"github.com/openfga/go-sdk/credentials"
+	"strings"
 
 	"github.com/openfga/cli/internal/build"
 )
@@ -27,14 +28,15 @@ import (
 var userAgent = "openfga-cli/" + build.Version
 
 type ClientConfig struct {
-	ApiUrl               string `json:"api_url,omitempty"` //nolint:revive,stylecheck
-	StoreID              string `json:"store_id,omitempty"`
-	AuthorizationModelID string `json:"authorization_model_id,omitempty"`
-	APIToken             string `json:"api_token,omitempty"`
-	APITokenIssuer       string `json:"api_token_issuer,omitempty"`
-	APIAudience          string `json:"api_audience,omitempty"`
-	ClientID             string `json:"client_id,omitempty"`
-	ClientSecret         string `json:"client_secret,omitempty"`
+	ApiUrl               string   `json:"api_url,omitempty"` //nolint:revive,stylecheck
+	StoreID              string   `json:"store_id,omitempty"`
+	AuthorizationModelID string   `json:"authorization_model_id,omitempty"`
+	APIToken             string   `json:"api_token,omitempty"`
+	APITokenIssuer       string   `json:"api_token_issuer,omitempty"`
+	APIAudience          string   `json:"api_audience,omitempty"`
+	ApiScopes            []string `json:"api_scopes,omitempty"`
+	ClientID             string   `json:"client_id,omitempty"`
+	ClientSecret         string   `json:"client_secret,omitempty"`
 }
 
 func (c ClientConfig) getCredentials() *credentials.Credentials {
@@ -55,6 +57,7 @@ func (c ClientConfig) getCredentials() *credentials.Credentials {
 				ClientCredentialsClientSecret:   c.ClientSecret,
 				ClientCredentialsApiAudience:    c.APIAudience,
 				ClientCredentialsApiTokenIssuer: c.APITokenIssuer,
+				ClientCredentialsScopes:         strings.Join(c.ApiScopes, " "),
 			},
 		}
 	}

--- a/internal/fga/fga.go
+++ b/internal/fga/fga.go
@@ -18,9 +18,10 @@ limitations under the License.
 package fga
 
 import (
+	"strings"
+
 	"github.com/openfga/go-sdk/client"
 	"github.com/openfga/go-sdk/credentials"
-	"strings"
 
 	"github.com/openfga/cli/internal/build"
 )
@@ -34,7 +35,7 @@ type ClientConfig struct {
 	APIToken             string   `json:"api_token,omitempty"`
 	APITokenIssuer       string   `json:"api_token_issuer,omitempty"`
 	APIAudience          string   `json:"api_audience,omitempty"`
-	ApiScopes            []string `json:"api_scopes,omitempty"`
+	APIScopes            []string `json:"api_scopes,omitempty"`
 	ClientID             string   `json:"client_id,omitempty"`
 	ClientSecret         string   `json:"client_secret,omitempty"`
 }
@@ -57,7 +58,7 @@ func (c ClientConfig) getCredentials() *credentials.Credentials {
 				ClientCredentialsClientSecret:   c.ClientSecret,
 				ClientCredentialsApiAudience:    c.APIAudience,
 				ClientCredentialsApiTokenIssuer: c.APITokenIssuer,
-				ClientCredentialsScopes:         strings.Join(c.ApiScopes, " "),
+				ClientCredentialsScopes:         strings.Join(c.APIScopes, " "),
 			},
 		}
 	}


### PR DESCRIPTION
Fully support OAuth2.

## Description
Add oauth2 scopes support, also update go-sdk to support full token endpoint url as issuer (and not only the host name).

## References
blocked by #235 
closes #231 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
