### PR TITLE
ci(goreleaser): create per-release brew formulae

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -119,7 +119,34 @@ docker_signs:
     - "--yes" # needed on cosign 2.0.0+
 
 brews:
-  - repository:
+  - name: "{{.ProjectName}}"
+    repository:
+      owner: openfga
+      name: homebrew-tap
+    homepage: "https://openfga.dev/"
+    description: "A cross-platform CLI to interact with an OpenFGA server."
+    license: "Apache-2.0"
+    folder: "Formula"
+    url_template: "https://github.com/openfga/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    download_strategy: CurlDownloadStrategy
+
+    # update the head formula on each release
+    custom_block: |
+      head "https://github.com/openfga/cli.git", :branch => "main"
+    dependencies:
+      - name: go
+        type: optional
+      - name: git
+    install: |
+      bin.install "fga"
+      bash_completion.install "completions/fga.bash" => "fga"
+      zsh_completion.install "completions/fga.zsh" => "_fga"
+      fish_completion.install "completions/fga.fish"
+      man1.install "manpages/fga.1.gz"
+    test: |
+      system "#{bin}/fga version"
+  - name: "{{.ProjectName}}@{{.Version}}"
+    repository:
       owner: openfga
       name: homebrew-tap
     homepage: "https://openfga.dev/"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

## Description
This PR updates the goreleaser configuration to create per-release brew formulae. This allows developers to install specific versions of the CLI:

```
brew install openfga/tap/fga@<version>
```

```
brew tap openfga/tap
brew install fga@<version>
```

## References
Closes #95.
Implemented based on [guidance from goreleaser](https://www.github.com/goreleaser/goreleaser/issues/4204).

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
