### PR TITLE
chore: cleanup FGA server resources

### DIFF
--- a/internal/storetest/localstore.go
+++ b/internal/storetest/localstore.go
@@ -75,8 +75,10 @@ func getLocalServerModelAndTuples(
 	format authorizationmodel.ModelFormat,
 ) (*server.Server, *authorizationmodel.AuthzModel, func(), error) {
 	var fgaServer *server.Server
-	stopServerFn := func() {}
+
 	var authModel *authorizationmodel.AuthzModel
+
+	stopServerFn := func() {}
 
 	if storeData.Model == "" {
 		return fgaServer, authModel, stopServerFn, nil

--- a/internal/storetest/tests.go
+++ b/internal/storetest/tests.go
@@ -36,10 +36,11 @@ func RunTests(
 ) (TestResults, error) {
 	test := TestResults{}
 
-	fgaServer, authModel, err := getLocalServerModelAndTuples(storeData, format)
+	fgaServer, authModel, stopServerFn, err := getLocalServerModelAndTuples(storeData, format)
 	if err != nil {
 		return test, err
 	}
+	defer stopServerFn()
 
 	for index := 0; index < len(storeData.Tests); index++ {
 		result, err := RunTest(

--- a/internal/storetest/tests.go
+++ b/internal/storetest/tests.go
@@ -40,6 +40,7 @@ func RunTests(
 	if err != nil {
 		return test, err
 	}
+
 	defer stopServerFn()
 
 	for index := 0; index < len(storeData.Tests); index++ {


### PR DESCRIPTION
## Description
This is a follow-up of https://github.com/openfga/openfga/pull/1318.

This PR cleans server resources properly.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
