### PR TITLE
chore: simplify test output

### DIFF
--- a/cmd/man.go
+++ b/cmd/man.go
@@ -32,7 +32,7 @@ var manCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Hidden:                true,
 	Args:                  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		manPage, err := mcobra.NewManPage(1, rootCmd.Root())
 		if err != nil {
 			return err //nolint:wrapcheck

--- a/cmd/model/get.go
+++ b/cmd/model/get.go
@@ -73,7 +73,7 @@ var getCmd = &cobra.Command{
 	Short:   "Read a Single Authorization Model",
 	Long:    "Read an authorization model, pass in an empty model ID to get latest.",
 	Example: `fga model get --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 
 		fgaClient, err := clientConfig.GetFgaClient()

--- a/cmd/model/list.go
+++ b/cmd/model/list.go
@@ -71,7 +71,7 @@ var listCmd = &cobra.Command{
 	Short:   "Read Authorization Models",
 	Long:    "List authorization models in a store.",
 	Example: "fga model list --store-id=01H0H015178Y2V4CX10C2KGHF4",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 		fgaClient, err := clientConfig.GetFgaClient()
 		if err != nil {

--- a/cmd/model/test.go
+++ b/cmd/model/test.go
@@ -34,7 +34,7 @@ var testCmd = &cobra.Command{
 	Short:   "Test an Authorization Model",
 	Long:    "Run a set of tests against a particular Authorization Model.",
 	Example: `fga model test --tests model.fga.yaml`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 
 		fgaClient, err := clientConfig.GetFgaClient()

--- a/cmd/model/validate_test.go
+++ b/cmd/model/validate_test.go
@@ -83,10 +83,12 @@ func TestValidate(t *testing.T) {
 			t.Parallel()
 
 			model := authorizationmodel.AuthzModel{}
+
 			err := model.ReadFromJSONString(test.Input)
 			if err != nil {
 				return
 			}
+
 			output := validate(model)
 
 			if !reflect.DeepEqual(output, test.ExpectedOutput) {

--- a/cmd/store/create.go
+++ b/cmd/store/create.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openfga/go-sdk/client"
@@ -60,7 +61,7 @@ func CreateStoreWithModel(
 	response := CreateStoreAndModelResponse{}
 
 	if storeName == "" {
-		return nil, fmt.Errorf(`required flag(s) "name" not set`) //nolint:goerr113
+		return nil, errors.New(`required flag(s) "name" not set`) //nolint:goerr113
 	}
 
 	createStoreResponse, err := create(fgaClient, storeName)

--- a/cmd/store/delete.go
+++ b/cmd/store/delete.go
@@ -34,7 +34,7 @@ var deleteCmd = &cobra.Command{
 	Short:   "Delete Store",
 	Long:    "Mark a store as deleted.",
 	Example: "fga store delete --store-id=01H0H015178Y2V4CX10C2KGHF4",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 		// First, confirm whether this is intended
 		force, err := cmd.Flags().GetBool("force")

--- a/cmd/store/get.go
+++ b/cmd/store/get.go
@@ -44,7 +44,7 @@ var getCmd = &cobra.Command{
 	Short:   "Get Store",
 	Long:    `Get a particular store.`,
 	Example: "fga store get --store-id=01H0H015178Y2V4CX10C2KGHF4",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 		fgaClient, err := clientConfig.GetFgaClient()
 		if err != nil {

--- a/cmd/store/import.go
+++ b/cmd/store/import.go
@@ -52,11 +52,13 @@ func importStore(
 	} else {
 		authModel := authorizationmodel.AuthzModel{}
 		clientConfig.StoreID = storeID
+
 		if format == authorizationmodel.ModelFormatJSON {
 			err = authModel.ReadFromJSONString(storeData.Model)
 		} else {
 			err = authModel.ReadFromDSLString(storeData.Model)
 		}
+
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
@@ -90,7 +92,7 @@ var importCmd = &cobra.Command{
 	Short:   "Import Store Data",
 	Long:    `Import a store: updating the name, model and appending the global tuples`,
 	Example: "fga store import --file=model.fga.yaml",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 
 		storeID, err := cmd.Flags().GetString("store-id")

--- a/cmd/store/list.go
+++ b/cmd/store/list.go
@@ -65,7 +65,7 @@ var listCmd = &cobra.Command{
 	Short:   "List Stores",
 	Long:    `Get a list of stores.`,
 	Example: "fga store list",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 		fgaClient, err := clientConfig.GetFgaClient()
 		if err != nil {

--- a/cmd/tuple/changes.go
+++ b/cmd/tuple/changes.go
@@ -71,7 +71,7 @@ var changesCmd = &cobra.Command{
 	Short:   "Read Relationship Tuple Changes (Watch)",
 	Long:    "Get a list of relationship tuple changes (Writes and Deletes) across time.",
 	Example: "fga tuple changes --store-id=01H0H015178Y2V4CX10C2KGHF4 --type document --continuation-token=MXw=",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 
 		fgaClient, err := clientConfig.GetFgaClient()

--- a/cmd/tuple/import.go
+++ b/cmd/tuple/import.go
@@ -138,7 +138,7 @@ var importCmd = &cobra.Command{
 	Deprecated: "use the write/delete command with the flag --file instead",
 	Long: "Imports Relationship Tuples to the store. " +
 		"This will write the tuples in chunks and at the end will report the tuple chunks that failed.",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 
 		fgaClient, err := clientConfig.GetFgaClient()

--- a/cmd/tuple/read.go
+++ b/cmd/tuple/read.go
@@ -103,7 +103,7 @@ var readCmd = &cobra.Command{
 	Short:   "Read Relationship Tuples",
 	Long:    "Read relationship tuples that exist in the system (does not evaluate).",
 	Example: "fga tuple read --store-id=01H0H015178Y2V4CX10C2KGHF4 --user user:anne --relation can_view --object document:roadmap", //nolint:lll
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 
 		fgaClient, err := clientConfig.GetFgaClient()

--- a/cmd/tuple/write.go
+++ b/cmd/tuple/write.go
@@ -18,6 +18,7 @@ package tuple
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openfga/go-sdk/client"
@@ -114,7 +115,7 @@ func writeTuplesFromFile(flags *flag.FlagSet, fgaClient *client.OpenFgaClient) e
 	}
 
 	if fileName == "" {
-		return fmt.Errorf("file name cannot be empty") //nolint:goerr113
+		return errors.New("file name cannot be empty") //nolint:goerr113
 	}
 
 	maxTuplesPerWrite, err := flags.GetInt("max-tuples-per-write")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -31,7 +31,7 @@ var versionCmd *cobra.Command = &cobra.Command{
 	Use:   "version",
 	Short: "Reports the FGA CLI version",
 	Long:  "Reports the FGA CLI version.",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		fmt.Printf("fga version %s\n", versionStr)
 
 		return nil

--- a/internal/cmdutils/get-contextual-tuples_test.go
+++ b/internal/cmdutils/get-contextual-tuples_test.go
@@ -65,6 +65,7 @@ func TestGetContextualTuplesWithNoError(t *testing.T) {
 		test := tests[index]
 		t.Run("TestGetContextualTuplesWithNoError"+string(rune(index)), func(t *testing.T) {
 			t.Parallel()
+
 			tuples, err := cmdutils.ParseContextualTuplesInner(test.raw)
 			if err != nil {
 				t.Error(err)
@@ -109,8 +110,8 @@ func TestGetContextualTuplesWithError(t *testing.T) {
 		test := tests[index]
 		t.Run("TestGetContextualTuplesWithNoError"+string(rune(index)), func(t *testing.T) {
 			t.Parallel()
-			_, err := cmdutils.ParseContextualTuplesInner(test.raw)
 
+			_, err := cmdutils.ParseContextualTuplesInner(test.raw)
 			if err == nil {
 				t.Error("Expect error but there is none")
 			}

--- a/internal/confirmation/confirmation_test.go
+++ b/internal/confirmation/confirmation_test.go
@@ -52,10 +52,12 @@ func TestConfirmation(t *testing.T) {
 		test := test
 		t.Run(test._name, func(t *testing.T) {
 			t.Parallel()
+
 			result, err := askForConfirmation(bufio.NewReader(strings.NewReader(test.input)), "test")
 			if err != nil {
 				t.Error(err)
 			}
+
 			if result != test.result {
 				t.Errorf("Expect result %v actual %v", test.result, result)
 			}


### PR DESCRIPTION
## Description
Simplify test output as outlined in https://github.com/openfga/cli/issues/251

## References
Closes https://github.com/openfga/cli/issues/251

## Sample output

I would be happy to change the output/code to suit what you prefer.

```
$ ./dist/fga model test --tests tests.fga.yaml
(FAILING) test-1: Checks (2/3 passing) | ListObjects (2/2 passing)
ⅹ Check(user=user:anne,relation=can_share,object=folder:1, context=<nil>): expected=false, got=true, error=<nil>
---
(FAILING) test-1b: Checks (2/3 passing) | ListObjects (1/2 passing)
ⅹ Check(user=user:anne,relation=can_share,object=folder:1, context=<nil>): expected=false, got=true, error=<nil>
ⅹ ListObjects(user=user:anne,relation=can_view,type=folder, context=<nil>): expected=[folder:2], got=[folder:1 folder:2], error=<nil>
---

# Test Summary #
Tests 2/4 passing
Checks 5/7 passing
ListObjects 6/7 passing
```