### PR TITLE
chore: simplify testing results output

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,11 +540,12 @@ tests: # required
 
 ```shell
 (FAILING) test-1: Checks (2/3 passing) | ListObjects (2/2 passing)
-✓ Check(user=user:anne,relation=can_write,object=folder:1)
-ⅹ Check(user=user:anne,relation=can_share,object=folder:1): expected=false, got=true, error=<nil>
-✓ Check(user=user:anne,relation=can_view,object=folder:1)
+ⅹ Check(user=user:anne,relation=can_share,object=folder:1): expected=false, got=true
 ---
-(PASSING) test-2: Checks (1/1 passing) | ListObjects (1/1 passing)
+# Test Summary #
+Tests 1/2 passing
+Checks 3/4 passing
+ListObjects 3/3 passing
 ```
 
 ##### Transform an Authorization Model

--- a/internal/storetest/testresult.go
+++ b/internal/storetest/testresult.go
@@ -58,7 +58,6 @@ func (result TestResult) IsPassing() bool {
 	return true
 }
 
-//nolint:cyclop
 func (result TestResult) FriendlyFailuresDisplay() string {
 	totalCheckCount := len(result.CheckResults)
 	failedCheckCount := 0
@@ -68,95 +67,127 @@ func (result TestResult) FriendlyFailuresDisplay() string {
 	listObjectsResultsOutput := ""
 
 	if totalCheckCount > 0 {
-		for index := 0; index < totalCheckCount; index++ {
-			checkResult := result.CheckResults[index]
-
-			if !checkResult.IsPassing() {
-				failedCheckCount++
-
-				got := "N/A"
-				if checkResult.Got != nil {
-					got = strconv.FormatBool(*checkResult.Got)
-				}
-
-				checkResultsOutput += fmt.Sprintf(
-					"\nⅹ Check(user=%s,relation=%s,object=%s",
-					checkResult.Request.User,
-					checkResult.Request.Relation,
-					checkResult.Request.Object)
-
-				if checkResult.Request.Context != nil {
-					checkResultsOutput += fmt.Sprintf(", context:%v", checkResult.Request.Context)
-				}
-
-				checkResultsOutput += fmt.Sprintf("): expected=%t, got=%s", checkResult.Expected, got)
-
-				if checkResult.Error != nil {
-					checkResultsOutput += fmt.Sprintf(", error=%v", checkResult.Error)
-				}
-			}
-		}
+		failedCheckCount, checkResultsOutput = buildCheckTestResults(
+			totalCheckCount, result, failedCheckCount, checkResultsOutput)
 	}
 
 	if totalListObjectsCount > 0 {
-		for index := 0; index < totalListObjectsCount; index++ {
-			listObjectsResult := result.ListObjectsResults[index]
+		failedListObjectsCount, listObjectsResultsOutput = buildListObjectsTestResults(
+			totalListObjectsCount, result, failedListObjectsCount, listObjectsResultsOutput)
+	}
 
-			if !listObjectsResult.IsPassing() {
-				failedListObjectsCount++
+	if failedCheckCount+failedListObjectsCount != 0 {
+		return buildTestResultOutput(
+			result, totalCheckCount,
+			failedCheckCount, totalListObjectsCount,
+			failedListObjectsCount, checkResultsOutput,
+			listObjectsResultsOutput)
+	}
 
-				got := "N/A"
-				if listObjectsResult.Got != nil {
-					got = fmt.Sprintf("%s", listObjectsResult.Got)
-				}
+	return ""
+}
 
-				listObjectsResultsOutput += fmt.Sprintf(
-					"\nⅹ ListObjects(user=%s,relation=%s,type=%s",
-					listObjectsResult.Request.User,
-					listObjectsResult.Request.Relation,
-					listObjectsResult.Request.Type)
+func buildCheckTestResults(totalCheckCount int,
+	result TestResult, failedCheckCount int,
+	checkResultsOutput string,
+) (int, string) {
+	for index := 0; index < totalCheckCount; index++ {
+		checkResult := result.CheckResults[index]
 
-				if listObjectsResult.Request.Context != nil {
-					listObjectsResultsOutput += fmt.Sprintf(", context:%v", listObjectsResult.Request.Context)
-				}
+		if !checkResult.IsPassing() {
+			failedCheckCount++
 
-				listObjectsResultsOutput += fmt.Sprintf("): expected=%s, got=%s", listObjectsResult.Expected, got)
+			got := "N/A"
+			if checkResult.Got != nil {
+				got = strconv.FormatBool(*checkResult.Got)
+			}
 
-				if listObjectsResult.Error != nil {
-					listObjectsResultsOutput += fmt.Sprintf(", error=%v", listObjectsResult.Error)
-				}
+			checkResultsOutput += fmt.Sprintf(
+				"\nⅹ Check(user=%s,relation=%s,object=%s",
+				checkResult.Request.User,
+				checkResult.Request.Relation,
+				checkResult.Request.Object)
+
+			if checkResult.Request.Context != nil {
+				checkResultsOutput += fmt.Sprintf(", context:%v", checkResult.Request.Context)
+			}
+
+			checkResultsOutput += fmt.Sprintf("): expected=%t, got=%s", checkResult.Expected, got)
+
+			if checkResult.Error != nil {
+				checkResultsOutput += fmt.Sprintf(", error=%v", checkResult.Error)
 			}
 		}
 	}
 
-	if failedCheckCount+failedListObjectsCount != 0 {
-		testStatus := "FAILING"
-		output := fmt.Sprintf("(%s) %s: ", testStatus, result.Name)
+	return failedCheckCount, checkResultsOutput
+}
 
-		if totalCheckCount > 0 {
-			output += fmt.Sprintf("Checks (%d/%d passing)", totalCheckCount-failedCheckCount, totalCheckCount)
+func buildListObjectsTestResults(
+	totalListObjectsCount int, result TestResult,
+	failedListObjectsCount int, listObjectsResultsOutput string,
+) (int, string) {
+	for index := 0; index < totalListObjectsCount; index++ {
+		listObjectsResult := result.ListObjectsResults[index]
+
+		if !listObjectsResult.IsPassing() {
+			failedListObjectsCount++
+
+			got := "N/A"
+			if listObjectsResult.Got != nil {
+				got = fmt.Sprintf("%s", listObjectsResult.Got)
+			}
+
+			listObjectsResultsOutput += fmt.Sprintf(
+				"\nⅹ ListObjects(user=%s,relation=%s,type=%s",
+				listObjectsResult.Request.User,
+				listObjectsResult.Request.Relation,
+				listObjectsResult.Request.Type)
+
+			if listObjectsResult.Request.Context != nil {
+				listObjectsResultsOutput += fmt.Sprintf(", context:%v", listObjectsResult.Request.Context)
+			}
+
+			listObjectsResultsOutput += fmt.Sprintf("): expected=%s, got=%s", listObjectsResult.Expected, got)
+
+			if listObjectsResult.Error != nil {
+				listObjectsResultsOutput += fmt.Sprintf(", error=%v", listObjectsResult.Error)
+			}
 		}
-
-		if totalCheckCount > 0 && totalListObjectsCount > 0 {
-			output += " | "
-		}
-
-		if totalListObjectsCount > 0 {
-			output += fmt.Sprintf("ListObjects (%d/%d passing)", totalListObjectsCount-failedListObjectsCount, totalListObjectsCount)
-		}
-
-		if failedCheckCount > 0 {
-			output = fmt.Sprintf("%s%s", output, checkResultsOutput)
-		}
-
-		if failedListObjectsCount > 0 {
-			output = fmt.Sprintf("%s%s", output, listObjectsResultsOutput)
-		}
-
-		return output
 	}
 
-	return ""
+	return failedListObjectsCount, listObjectsResultsOutput
+}
+
+func buildTestResultOutput(result TestResult, totalCheckCount int, failedCheckCount int,
+	totalListObjectsCount int, failedListObjectsCount int,
+	checkResultsOutput string, listObjectsResultsOutput string,
+) string {
+	testStatus := "FAILING"
+	output := fmt.Sprintf("(%s) %s: ", testStatus, result.Name)
+
+	if totalCheckCount > 0 {
+		output += fmt.Sprintf("Checks (%d/%d passing)", totalCheckCount-failedCheckCount, totalCheckCount)
+	}
+
+	if totalCheckCount > 0 && totalListObjectsCount > 0 {
+		output += " | "
+	}
+
+	if totalListObjectsCount > 0 {
+		output += fmt.Sprintf("ListObjects (%d/%d passing)",
+			totalListObjectsCount-failedListObjectsCount, totalListObjectsCount)
+	}
+
+	if failedCheckCount > 0 {
+		output = fmt.Sprintf("%s%s", output, checkResultsOutput)
+	}
+
+	if failedListObjectsCount > 0 {
+		output = fmt.Sprintf("%s%s", output, listObjectsResultsOutput)
+	}
+
+	return output
 }
 
 type TestResults struct {
@@ -217,19 +248,32 @@ func (test TestResults) FriendlyDisplay() string {
 	summary := failuresText
 
 	if totalTestCount > 0 {
-		if failedTestCount > 0 {
-			summary += "\n---\n"
-		}
+		summary = buildTestSummary(
+			failedTestCount, summary, totalTestCount, totalCheckCount, failedCheckCount,
+			totalListObjectsCount, failedListObjectsCount)
+	}
 
-		summary += fmt.Sprintf("# Test Summary #\nTests %d/%d passing", totalTestCount-failedTestCount, totalTestCount)
+	return summary
+}
 
-		if totalCheckCount > 0 {
-			summary += fmt.Sprintf("\nChecks %d/%d passing", totalCheckCount-failedCheckCount, totalCheckCount)
-		}
+func buildTestSummary(failedTestCount int, summary string, totalTestCount int,
+	totalCheckCount int, failedCheckCount int, totalListObjectsCount int, failedListObjectsCount int,
+) string {
+	if failedTestCount > 0 {
+		summary += "\n---\n"
+	}
 
-		if totalListObjectsCount > 0 {
-			summary += fmt.Sprintf("\nListObjects %d/%d passing", totalListObjectsCount-failedListObjectsCount, totalListObjectsCount)
-		}
+	summary += fmt.Sprintf("# Test Summary #\nTests %d/%d passing",
+		totalTestCount-failedTestCount, totalTestCount)
+
+	if totalCheckCount > 0 {
+		summary += fmt.Sprintf("\nChecks %d/%d passing",
+			totalCheckCount-failedCheckCount, totalCheckCount)
+	}
+
+	if totalListObjectsCount > 0 {
+		summary += fmt.Sprintf("\nListObjects %d/%d passing",
+			totalListObjectsCount-failedListObjectsCount, totalListObjectsCount)
 	}
 
 	return summary

--- a/internal/storetest/testresult.go
+++ b/internal/storetest/testresult.go
@@ -79,17 +79,21 @@ func (result TestResult) FriendlyFailuresDisplay() string {
 					got = strconv.FormatBool(*checkResult.Got)
 				}
 
-				checkResultsOutput = fmt.Sprintf(
-					"%s\nⅹ Check(user=%s,relation=%s,object=%s, context=%v): expected=%t, got=%s, error=%v",
-					checkResultsOutput,
+				checkResultsOutput += fmt.Sprintf(
+					"\nⅹ Check(user=%s,relation=%s,object=%s",
 					checkResult.Request.User,
 					checkResult.Request.Relation,
-					checkResult.Request.Object,
-					checkResult.Request.Context,
-					checkResult.Expected,
-					got,
-					checkResult.Error,
-				)
+					checkResult.Request.Object)
+
+				if checkResult.Request.Context != nil {
+					checkResultsOutput += fmt.Sprintf(", context:%v", checkResult.Request.Context)
+				}
+
+				checkResultsOutput += fmt.Sprintf("): expected=%t, got=%s", checkResult.Expected, got)
+
+				if checkResult.Error != nil {
+					checkResultsOutput += fmt.Sprintf(", error=%v", checkResult.Error)
+				}
 			}
 		}
 	}
@@ -106,32 +110,40 @@ func (result TestResult) FriendlyFailuresDisplay() string {
 					got = fmt.Sprintf("%s", listObjectsResult.Got)
 				}
 
-				listObjectsResultsOutput = fmt.Sprintf(
-					"%s\nⅹ ListObjects(user=%s,relation=%s,type=%s, context=%v): expected=%s, got=%s, error=%v",
-					listObjectsResultsOutput,
+				listObjectsResultsOutput += fmt.Sprintf(
+					"\nⅹ ListObjects(user=%s,relation=%s,type=%s",
 					listObjectsResult.Request.User,
 					listObjectsResult.Request.Relation,
-					listObjectsResult.Request.Type,
-					listObjectsResult.Request.Context,
-					listObjectsResult.Expected,
-					got,
-					listObjectsResult.Error,
-				)
+					listObjectsResult.Request.Type)
+
+				if listObjectsResult.Request.Context != nil {
+					listObjectsResultsOutput += fmt.Sprintf(", context:%v", listObjectsResult.Request.Context)
+				}
+
+				listObjectsResultsOutput += fmt.Sprintf("): expected=%s, got=%s", listObjectsResult.Expected, got)
+
+				if listObjectsResult.Error != nil {
+					listObjectsResultsOutput += fmt.Sprintf(", error=%v", listObjectsResult.Error)
+				}
 			}
 		}
 	}
 
 	if failedCheckCount+failedListObjectsCount != 0 {
 		testStatus := "FAILING"
-		output := fmt.Sprintf(
-			"(%s) %s: Checks (%d/%d passing) | ListObjects (%d/%d passing)",
-			testStatus,
-			result.Name,
-			totalCheckCount-failedCheckCount,
-			totalCheckCount,
-			totalListObjectsCount-failedListObjectsCount,
-			totalListObjectsCount,
-		)
+		output := fmt.Sprintf("(%s) %s: ", testStatus, result.Name)
+
+		if totalCheckCount > 0 {
+			output += fmt.Sprintf("Checks (%d/%d passing)", totalCheckCount-failedCheckCount, totalCheckCount)
+		}
+
+		if totalCheckCount > 0 && totalListObjectsCount > 0 {
+			output += " | "
+		}
+
+		if totalListObjectsCount > 0 {
+			output += fmt.Sprintf("ListObjects (%d/%d passing)", totalListObjectsCount-failedListObjectsCount, totalListObjectsCount)
+		}
 
 		if failedCheckCount > 0 {
 			output = fmt.Sprintf("%s%s", output, checkResultsOutput)
@@ -202,12 +214,23 @@ func (test TestResults) FriendlyDisplay() string {
 		}
 	}
 
-	summary := fmt.Sprintf(
-		"\n---\n\n# Test Summary #\nTests %d/%d passing\nChecks %d/%d passing\nListObjects %d/%d passing",
-		totalTestCount-failedTestCount, totalTestCount,
-		totalCheckCount-failedCheckCount, totalCheckCount,
-		totalListObjectsCount-failedListObjectsCount, totalListObjectsCount,
-	)
+	summary := failuresText
 
-	return failuresText + summary
+	if totalTestCount > 0 {
+		if failedTestCount > 0 {
+			summary += "\n---\n"
+		}
+
+		summary += fmt.Sprintf("# Test Summary #\nTests %d/%d passing", totalTestCount-failedTestCount, totalTestCount)
+
+		if totalCheckCount > 0 {
+			summary += fmt.Sprintf("\nChecks %d/%d passing", totalCheckCount-failedCheckCount, totalCheckCount)
+		}
+
+		if totalListObjectsCount > 0 {
+			summary += fmt.Sprintf("\nListObjects %d/%d passing", totalListObjectsCount-failedListObjectsCount, totalListObjectsCount)
+		}
+	}
+
+	return summary
 }


### PR DESCRIPTION
## Description

Test results displayed information that was not necessarily relevant:

- When the number of tests run for a specific method (check/listobjects) was 0, it displayed 0 instead of not showing anything
- When no `context` was provided, it showed `context =<nil>` instead of  not showing it
- When no `error` was returned, it showed `error =<nil>` instead of  not showing it
- When no tests failed, it showed two new lines and a separator, before showing the summary, when it was not needed

This PR addresses this by not showing unnecessary data.

I tested manually:

- If an error is returned, it should be displayed
- If context is provided, it should be displayed
- If there aren't any Check or LIstObjects tests, the tests result should not mention those

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
