### PR TITLE
feat: support referencing an fga.mod file in a store

### DIFF
--- a/cmd/store/create.go
+++ b/cmd/store/create.go
@@ -74,12 +74,8 @@ func CreateStoreWithModel(
 
 	if inputModel != "" {
 		authModel := authorizationmodel.AuthzModel{}
-		if inputFormat == authorizationmodel.ModelFormatJSON {
-			err = authModel.ReadFromJSONString(inputModel)
-		} else {
-			err = authModel.ReadFromDSLString(inputModel)
-		}
 
+		err = authModel.ReadModelFromString(inputModel, inputFormat)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}

--- a/cmd/store/import.go
+++ b/cmd/store/import.go
@@ -43,7 +43,7 @@ func importStore(
 	maxParallelRequests int,
 ) error {
 	var err error
-	if storeID == "" { //nolint:nestif
+	if storeID == "" {
 		createStoreAndModelResponse, err := CreateStoreWithModel(clientConfig, storeData.Name, storeData.Model, format)
 		if err != nil {
 			return err
@@ -53,12 +53,7 @@ func importStore(
 		authModel := authorizationmodel.AuthzModel{}
 		clientConfig.StoreID = storeID
 
-		if format == authorizationmodel.ModelFormatJSON {
-			err = authModel.ReadFromJSONString(storeData.Model)
-		} else {
-			err = authModel.ReadFromDSLString(storeData.Model)
-		}
-
+		err = authModel.ReadModelFromString(storeData.Model, format)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}

--- a/internal/storetest/localstore.go
+++ b/internal/storetest/localstore.go
@@ -87,20 +87,19 @@ func getLocalServerModelAndTuples(
 	// If we have at least one local test, initialize the local server
 	datastore := memory.New()
 
-	fgaServer, err := server.NewServerWithOpts(server.WithDatastore(datastore))
+	fgaServer, err := server.NewServerWithOpts(
+		server.WithDatastore(datastore),
+		server.WithExperimentals(server.ExperimentalEnableModularModels),
+	)
 	if err != nil {
 		return nil, nil, stopServerFn, err //nolint:wrapcheck
 	}
 
 	tempModel := authorizationmodel.AuthzModel{}
-	if format == authorizationmodel.ModelFormatJSON {
-		if err := tempModel.ReadFromJSONString(storeData.Model); err != nil {
-			return nil, nil, stopServerFn, err //nolint:wrapcheck
-		}
-	} else {
-		if err := tempModel.ReadFromDSLString(storeData.Model); err != nil {
-			return nil, nil, stopServerFn, err //nolint:wrapcheck
-		}
+
+	err = tempModel.ReadModelFromString(storeData.Model, format)
+	if err != nil {
+		return nil, nil, stopServerFn, err //nolint:wrapcheck
 	}
 
 	authModel = &tempModel


### PR DESCRIPTION
## Description

Adds support for handling `model_file` in a store file pointing at an `fga.mod` file, this completes with support for both the `model test` and `store import` command.

In order to test the `import` command you'll need [this branch](https://github.com/openfga/openfga/tree/feat/1402-schema-12-support) of openfga checked out and started with `openfga run --experimentals=enable-modular-models`, that will then allow importing by referencing the `fga.mod` file in the modular-models-example repo

## References

Closes #269 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
