### PR TITLE
feat: support passing an fga.mod file for the --file argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ fga store **create**
 
 ###### Parameters
 * `--name`: Name of the store to be created. If the `model` parameter is specified, the model file name will be used as the default store name. 
-* `--model`: File with the authorization model. Can be in JSON or OpenFGA format (optional).
-* `--format` : Authorization model input format. Can be "fga" or "json" (optional, defaults to the model file extension if present).
+* `--model`: File with the authorization model. Can be in JSON, OpenFGA format, or fga.mod file (optional).
+* `--format` : Authorization model input format. Can be "fga", "json", or "modular" (optional, defaults to the model file extension if present).
 
 ###### Example
 `fga store create --name "FGA Demo Store"`
@@ -352,7 +352,7 @@ fga model **write**
 ###### Parameters
 * `--store-id`: Specifies the store id
 * `--file`: File containing the authorization model.
-* `--format`: Authorization model input format. Can be "fga" or "json". Defaults to the file extension if provided (optional)
+* `--format`: Authorization model input format. Can be "fga", "json", or "modular". Defaults to the file extension if provided (optional)
 
 ###### Example
 * `fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 --file model.fga`
@@ -423,7 +423,7 @@ fga model **validate**
 
 ###### Parameters
 * `--file`: File containing the authorization model.
-* `--format`: Authorization model input format. Can be "fga" or "json". Defaults to the file extension if provided (optional)
+* `--format`: Authorization model input format. Can be "fga", "json", or "modular". Defaults to the file extension if provided (optional)
 
 ###### Example
 `fga model validate --file model.json`
@@ -555,7 +555,7 @@ fga model **transform**
 
 ###### Parameters
 * `--file`: File containing the authorization model
-* `--input-format`: Authorization model input format. Can be "fga" or "json". Defaults to the file extension if provided (optional)
+* `--input-format`: Authorization model input format. Can be "fga", "json", or "modular". Defaults to the file extension if provided (optional)
 
 ###### Example
 `fga model transform --file model.json`

--- a/cmd/model/transform.go
+++ b/cmd/model/transform.go
@@ -32,7 +32,8 @@ var transformCmd = &cobra.Command{
 	Short: "Transforms an authorization model",
 	Example: `fga model transform --file=model.json
 fga model transform --file=model.fga
-fga model transform '{ "schema_version": "1.1", "type_definitions":[{"type":"user"}] }' --input-format json`,
+fga model transform '{ "schema_version": "1.1", "type_definitions":[{"type":"user"}] }' --input-format json
+fga model transform --file=fga.mod`,
 
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -75,6 +76,6 @@ fga model transform '{ "schema_version": "1.1", "type_definitions":[{"type":"use
 var transformInputFormat = authorizationmodel.ModelFormatDefault
 
 func init() {
-	transformCmd.Flags().String("file", "", "File Name. The file should have the model in the JSON or DSL format")
-	transformCmd.Flags().Var(&transformInputFormat, "input-format", `Authorization model input format. Can be "fga" or "json"`) //nolint:lll
+	transformCmd.Flags().String("file", "", "File Name. The file should have the model in the JSON or DSL format or be an `fga.mod` format") //nolint:lll
+	transformCmd.Flags().Var(&transformInputFormat, "input-format", `Authorization model input format. Can be "fga", "json", or "modular"`)  //nolint:lll
 }

--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -108,14 +108,8 @@ var validateCmd = &cobra.Command{
 		}
 
 		authModel := authorizationmodel.AuthzModel{}
-		var err error
 
-		if validateInputFormat == authorizationmodel.ModelFormatJSON {
-			err = authModel.ReadFromJSONString(inputModel)
-		} else {
-			err = authModel.ReadFromDSLString(inputModel)
-		}
-
+		err := authModel.ReadModelFromString(inputModel, validateInputFormat)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
@@ -129,6 +123,6 @@ var validateCmd = &cobra.Command{
 var validateInputFormat = authorizationmodel.ModelFormatDefault
 
 func init() {
-	validateCmd.Flags().String("file", "", "File Name. The file should have the model in the JSON or DSL format")
-	validateCmd.Flags().Var(&validateInputFormat, "format", `Authorization model input format. Can be "fga" or "json"`)
+	validateCmd.Flags().String("file", "", "File Name. The file should have the model in the JSON or DSL format or be an fga.mod file") //nolint:lll
+	validateCmd.Flags().Var(&validateInputFormat, "format", `Authorization model input format. Can be "fga", "json", or "modular"`)     //nolint:lll
 }

--- a/cmd/model/write.go
+++ b/cmd/model/write.go
@@ -78,12 +78,7 @@ fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 '{"type_definitions":[{"ty
 
 		authModel := authorizationmodel.AuthzModel{}
 
-		if writeInputFormat == authorizationmodel.ModelFormatJSON {
-			err = authModel.ReadFromJSONString(inputModel)
-		} else {
-			err = authModel.ReadFromDSLString(inputModel)
-		}
-
+		err = authModel.ReadModelFromString(inputModel, writeInputFormat)
 		if err != nil {
 			return err //nolint:wrapcheck
 		}

--- a/cmd/store/create.go
+++ b/cmd/store/create.go
@@ -132,5 +132,5 @@ var createModelInputFormat = authorizationmodel.ModelFormatDefault
 func init() {
 	createCmd.Flags().String("name", "", "Store Name")
 	createCmd.Flags().String("model", "", "Authorization Model File Name")
-	createCmd.Flags().Var(&createModelInputFormat, "format", `Authorization model input format. Can be "fga" or "json"`)
+	createCmd.Flags().Var(&createModelInputFormat, "format", `Authorization model input format. Can be "fga", "json" or "modular`) //nolint:lll
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/nwidger/jsoncolor v0.3.2
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/openfga/api/proto v0.0.0-20240312180017-0c609904ae24
-	github.com/openfga/go-sdk v0.3.5
+	github.com/openfga/go-sdk v0.3.6-0.20240313140700-3de2c059df44
 	github.com/openfga/language/pkg/go v0.0.0-20240312223328-605a55c5f880
 	github.com/openfga/openfga v1.5.1-0.20240312222040-3f13843536d9
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/openfga/api/proto v0.0.0-20240312180017-0c609904ae24 h1:1mFm89i8/yguJ
 github.com/openfga/api/proto v0.0.0-20240312180017-0c609904ae24/go.mod h1:5LtWOArDX4FlbcfDvBoJAzDEYJKLz/OEUoi+0S2tyM8=
 github.com/openfga/go-sdk v0.3.5 h1:KQXhMREh+g/K7HNuZ/YmXuHkREkq0VMKteua4bYr3Uw=
 github.com/openfga/go-sdk v0.3.5/go.mod h1:u1iErzj5E9/bhe+8nsMv0gigcYbJtImcdgcE5DmpbBg=
+github.com/openfga/go-sdk v0.3.6-0.20240313140700-3de2c059df44 h1:JyFxbUvKEqMnCoJL4QoH70kpBxkFaHtmo4tFNKIsfoo=
+github.com/openfga/go-sdk v0.3.6-0.20240313140700-3de2c059df44/go.mod h1:dybCHDtJDwkmtlxxtgQrHR2c8HPVOwN493drbXv46Ec=
 github.com/openfga/language/pkg/go v0.0.0-20240312222412-7d8ae9182e09 h1:zFyslv7PQyAImXh/2NqcfEGZfmMopf6sTk+OZygfPnw=
 github.com/openfga/language/pkg/go v0.0.0-20240312222412-7d8ae9182e09/go.mod h1:iwtNOC/ypBBmN4ND4JqtLdgskIEN67GRP6HuTVa0dKE=
 github.com/openfga/language/pkg/go v0.0.0-20240312223328-605a55c5f880 h1:lqPDk9xsY8NYxfaxjj66Dj/yThVGrbp8tWVgHDYVrD4=

--- a/internal/authorizationmodel/model.go
+++ b/internal/authorizationmodel/model.go
@@ -265,8 +265,7 @@ func (model *AuthzModel) ReadModelFromString(input string, format ModelFormat) e
 		}
 
 		return nil
-	case ModelFormatFGA:
-	case ModelFormatDefault:
+	case ModelFormatFGA, ModelFormatDefault:
 		if err := model.ReadFromDSLString(input); err != nil {
 			return err
 		}

--- a/internal/authorizationmodel/read-from-input.go
+++ b/internal/authorizationmodel/read-from-input.go
@@ -52,6 +52,10 @@ func ReadFromFile(
 		default:
 			*format = ModelFormatFGA
 		}
+	} else if *format == ModelFormatModular {
+		// If we're provided a modular model we want the input to be the filename as we will handle
+		// reading and parsing the fga.mod file later
+		*input = fileName
 	}
 
 	if *storeName == "" {


### PR DESCRIPTION
## Description

Extends/verifies modular models support for the remaining commands stated in #270, this mostly is documentation updates with a couple bug fixes for the following:

* Corrects an incorrect switch statement for reading models
* Adds handling for to `ReadFromFile` for when we've been provided the input format on the command line

## References

Closes #270

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
