### PR TITLE
chore: allow dx to approve readme changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @openfga/dx
-README.md @openfga/product @openfga/community
+README.md @openfga/product @openfga/community @openfga/dx


### PR DESCRIPTION
## Description

Based on https://github.com/openfga/sdk-generator/pull/322 I think the intention is for readme changes approvers to be community, product and DX but I guess GH codeowners doesn't apply DX to the readme from the * rule 

## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
