### PR TITLE
doc(model/write): add missing example to readme, correct help text example

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,8 @@ fga model **write**
 * `--format`: Authorization model input format. Can be "fga", "json", or "modular". Defaults to the file extension if provided (optional)
 
 ###### Example
-* `fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 --file model.fga`
+* `fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 --file=model.fga`
+* `fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 --file=fga.mod`
 * `fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 '{"type_definitions": [ { "type": "user" }, { "type": "document", "relations": { "can_view": { "this": {} } }, "metadata": { "relations": { "can_view": { "directly_related_user_types": [ { "type": "user" } ] }}}} ], "schema_version": "1.1"}' --format json`
 
 ###### Response

--- a/cmd/model/write.go
+++ b/cmd/model/write.go
@@ -54,7 +54,8 @@ var writeCmd = &cobra.Command{
 	Short: "Write Authorization Model",
 	Long:  "Writes a new authorization model.",
 	Example: `fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 --file=model.json
-fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 '{"type_definitions":[{"type":"user"},{"type":"document","relations":{"can_view":{"this":{}}},"metadata":{"relations":{"can_view":{"directly_related_user_types":[{"type":"user"}]}}}}],"schema_version":"1.1"}'`, //nolint:lll
+fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 --file=fga.mod
+fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 '{"type_definitions":[{"type":"user"},{"type":"document","relations":{"can_view":{"this":{}}},"metadata":{"relations":{"can_view":{"directly_related_user_types":[{"type":"user"}]}}}}],"schema_version":"1.1"}' --format=json`, //nolint:lll
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
@@ -97,7 +98,7 @@ var writeInputFormat = authorizationmodel.ModelFormatDefault
 func init() {
 	writeCmd.Flags().String("store-id", "", "Store ID")
 	writeCmd.Flags().String("file", "", "File Name. The file should have the model in the JSON or DSL format")
-	writeCmd.Flags().Var(&writeInputFormat, "format", `Authorization model input format. Can be "fga" or "json"`)
+	writeCmd.Flags().Var(&writeInputFormat, "format", `Authorization model input format. Can be "fga", "json", or "modular"`) //nolint:lll
 
 	if err := writeCmd.MarkFlagRequired("store-id"); err != nil {
 		fmt.Printf("error setting flag as required - %v: %v\n", "cmd/models/write", err)

--- a/internal/authorizationmodel/format.go
+++ b/internal/authorizationmodel/format.go
@@ -47,5 +47,5 @@ func (format *ModelFormat) Set(v string) error {
 }
 
 func (format *ModelFormat) Type() string {
-	return "ModelFormat"
+	return "format"
 }


### PR DESCRIPTION
## Description

Adds a modular write example to the readme and fixes the JSON write example in the command help text

## References

Closes #291

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
