### PR TITLE
feat: fga store import displays the generated store and model details

### DIFF
--- a/cmd/store/import.go
+++ b/cmd/store/import.go
@@ -43,11 +43,11 @@ func importStore(
 	maxParallelRequests int,
 ) (*CreateStoreAndModelResponse, error) {
 	var err error
-	var response *CreateStoreAndModelResponse
-	if storeID == "" {
+	var response *CreateStoreAndModelResponse //nolint:wsl
+	if storeID == "" {                        //nolint:wsl
 		createStoreAndModelResponse, err := CreateStoreWithModel(clientConfig, storeData.Name, storeData.Model, format)
 		response = createStoreAndModelResponse
-		if err != nil {
+		if err != nil { //nolint:wsl
 			return nil, err
 		}
 		clientConfig.StoreID = createStoreAndModelResponse.Store.Id //nolint:wsl
@@ -123,7 +123,8 @@ var importCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize FGA Client due to %w", err)
 		}
 
-		createStoreAndModelResponse, err = importStore(clientConfig, fgaClient, storeData, format, storeID, maxTuplesPerWrite, maxParallelRequests)
+		createStoreAndModelResponse, err = importStore(clientConfig, fgaClient, storeData, format,
+			storeID, maxTuplesPerWrite, maxParallelRequests)
 		if err != nil {
 			return err
 		}

--- a/cmd/store/import.go
+++ b/cmd/store/import.go
@@ -41,12 +41,14 @@ func importStore(
 	storeID string,
 	maxTuplesPerWrite int,
 	maxParallelRequests int,
-) error {
+) (*CreateStoreAndModelResponse, error) {
 	var err error
+	var response *CreateStoreAndModelResponse
 	if storeID == "" {
 		createStoreAndModelResponse, err := CreateStoreWithModel(clientConfig, storeData.Name, storeData.Model, format)
+		response = createStoreAndModelResponse
 		if err != nil {
-			return err
+			return nil, err
 		}
 		clientConfig.StoreID = createStoreAndModelResponse.Store.Id //nolint:wsl
 	} else {
@@ -55,18 +57,18 @@ func importStore(
 
 		err = authModel.ReadModelFromString(storeData.Model, format)
 		if err != nil {
-			return err //nolint:wrapcheck
+			return nil, err //nolint:wrapcheck
 		}
 
 		_, err := model.Write(fgaClient, authModel)
 		if err != nil {
-			return fmt.Errorf("failed to write model due to %w", err)
+			return nil, fmt.Errorf("failed to write model due to %w", err)
 		}
 	}
 
 	fgaClient, err = clientConfig.GetFgaClient()
 	if err != nil {
-		return fmt.Errorf("failed to initialize FGA Client due to %w", err)
+		return nil, fmt.Errorf("failed to initialize FGA Client due to %w", err)
 	}
 
 	writeRequest := client.ClientWriteRequest{
@@ -75,10 +77,10 @@ func importStore(
 
 	_, err = tuple.ImportTuples(fgaClient, writeRequest, maxTuplesPerWrite, maxParallelRequests)
 	if err != nil {
-		return err //nolint:wrapcheck
+		return nil, err //nolint:wrapcheck
 	}
 
-	return nil
+	return response, nil
 }
 
 // importCmd represents the get command.
@@ -88,6 +90,7 @@ var importCmd = &cobra.Command{
 	Long:    `Import a store: updating the name, model and appending the global tuples`,
 	Example: "fga store import --file=model.fga.yaml",
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		var createStoreAndModelResponse *CreateStoreAndModelResponse
 		clientConfig := cmdutils.GetClientConfig(cmd)
 
 		storeID, err := cmd.Flags().GetString("store-id")
@@ -120,12 +123,12 @@ var importCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize FGA Client due to %w", err)
 		}
 
-		err = importStore(clientConfig, fgaClient, storeData, format, storeID, maxTuplesPerWrite, maxParallelRequests)
+		createStoreAndModelResponse, err = importStore(clientConfig, fgaClient, storeData, format, storeID, maxTuplesPerWrite, maxParallelRequests)
 		if err != nil {
 			return err
 		}
 
-		return output.Display(output.EmptyStruct{})
+		return output.Display(createStoreAndModelResponse)
 	},
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
importStore function in `/cmd/store/import.go` now also returns the response details after creating store with model which is used in importCmd to display those details
Fixes #298 
## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
