### PR TITLE
feat(model/transform): support specifying an output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,8 @@ fga model **transform**
 ###### Parameters
 * `--file`: File containing the authorization model
 * `--input-format`: Authorization model input format. Can be "fga", "json", or "modular". Defaults to the file extension if provided (optional)
+* `--output-format`: Authorization model output format. Can be "fga" or "json". If input format is `json` then it defaults to DSL, if `fga` or `modular` then defaults to `json` (optional)
+
 
 ###### Example
 `fga model transform --file model.json`

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ fga model **transform**
 ###### Parameters
 * `--file`: File containing the authorization model
 * `--input-format`: Authorization model input format. Can be "fga", "json", or "modular". Defaults to the file extension if provided (optional)
-* `--output-format`: Authorization model output format. Can be "fga" or "json". If input format is `json` then it defaults to DSL, if `fga` or `modular` then defaults to `json` (optional)
+* `--output-format`: Authorization model output format. Can be "fga" or "json". If not specified, it will default to `fga` if the input format is `json` and to `json` otherwise (optional)
 
 
 ###### Example


### PR DESCRIPTION
## Description

Adds support for a `--output-format` option that allows specifying `fga` or `json` for the transform output, this is optional and will continue to support outputting `fga` for `json` input and `json` for `fga` and `modular` inputs.

It doesn't prevent transforming to the same as the input as while not useful, it will work so shouldn't be an error case.

## References

Closes #307


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
