### PR TITLE
release: v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-### [0.3.0-beta.1](https://github.com/openfga/cli/compare/v0.2.7...v0.3.0) (2024-03-28)
+### [0.3.1](https://github.com/openfga/cli/compare/v0.3.0...v0.3.1) (2024-04-29)
+
+Added:
+
+- `fga store import` now outputs the store and model details (#299) - thanks @NeerajNagure
+- `fga store export` to support exporting a store (#306)
+- Support specifying output format using `--output-format` for `fga model transform` (#308)
+
+Changed:
+- `fga tuple write` returns simpler error messages (#303) - thanks @shruti2522
+
+### [0.3.0](https://github.com/openfga/cli/compare/v0.2.7...v0.3.0) (2024-03-28)
 
 Added:
 - Support for [modular models](https://github.com/openfga/rfcs/blob/main/20231212-modular-models.md) ([#262](https://github.com/openfga/cli/issues/262))


### PR DESCRIPTION
## Description

Adds changelog entry for v0.3.1

Added:

- `fga store import` now outputs the store and model details (#299)
- `fga store export` to support exporting a store (#306)
- Support specifying output format using `--output-format` for `fga model transform` (#308)

Changed:
- `fga tuple write` returns simpler error messages (#303)

## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
