### PR TITLE
feat(query): support running a query against list-users api

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A cross-platform CLI to interact with an OpenFGA server
       - [Expand](#expand)
       - [List Objects](#list-objects)
       - [List Relations](#list-relations)
+      - [List Users](#list-users)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -1111,19 +1112,7 @@ fga query **list-users** --object <object> --relation <relation> --user-filter <
             "type": "user",
             "id": "anne"
           }
-        },
-        {
-          "wildcard": {
-            "type":"user"
-          }
-        },
-        {
-          "userset": {
-            "id":"eng",
-            "relation":"member",
-            "type":"group"
-          }
-        },
+        }
       ]
     }
 }

--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,61 @@ fga query **expand** <relation> <object> --store-id=<store-id> [--model-id=<mode
 }
 ```
 
+##### List Users
+
+###### Command
+fga query **list-users** --object <object> --relation <relation> --user-filter <user-filter> [--contextual-tuple "<user> <relation> <object>"]* --store-id=<store-id> [--model-id=<model-id>]
+
+###### Parameters
+* `--store-id`: Specifies the store id
+* `--object`: Specifies the object to list users for
+* `--relation`: Specifies the relation to search on
+* `--user-filter`: Specifies the type or userset to filter with
+* `--model-id`: Specifies the model id to target (optional)
+* `--contextual-tuple`: Contextual tuples (optional) (can be multiple)
+* `--context`: Condition context (optional)
+
+###### Example
+`fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view --user-filter user`
+`fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view --user-filter user --contextual-tuple "user:anne can_view folder:product"`
+`fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view --user-filter group#member --context '{"ip_address":"127.0.0.1"}`
+
+###### Response
+```json5
+{
+    {
+      "excluded_users": [
+        {
+          "object": {
+            "type": "user",
+            "id": "beth"
+          }
+        }
+      ],
+      "users": [
+        {
+          "object": {
+            "type": "user",
+            "id": "anne"
+          }
+        },
+        {
+          "wildcard": {
+            "type":"user"
+          }
+        },
+        {
+          "userset": {
+            "id":"eng",
+            "relation":"member",
+            "type":"group"
+          }
+        },
+      ]
+    }
+}
+```
+
 ## Contributing
 
 See [CONTRIBUTING](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md).

--- a/cmd/query/list-users.go
+++ b/cmd/query/list-users.go
@@ -78,7 +78,7 @@ func listUsers(
 
 	response, err := fgaClient.ListUsers(context.Background()).Body(*body).Options(*options).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list relations due to %w", err)
+		return nil, fmt.Errorf("failed to list users due to %w", err)
 	}
 
 	return response, nil
@@ -87,7 +87,7 @@ func listUsers(
 var listUsersCmd = &cobra.Command{
 	Use:     "list-users",
 	Short:   "List users",
-	Long:    "List all users that are associated with an object",
+	Long:    "List all users that have a certain relation with a particular object",
 	Example: `fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
@@ -121,8 +121,8 @@ var listUsersCmd = &cobra.Command{
 
 func init() {
 	listUsersCmd.Flags().String("object", "", "Object to list users for")
-	listUsersCmd.Flags().String("relation", "", "Relation to search on")
-	listUsersCmd.Flags().String("user-filter", "", "Type or userset to filter to")
+	listUsersCmd.Flags().String("relation", "", "Relation to evaluate on")
+	listUsersCmd.Flags().String("user-filter", "", "Filter the responses can be in the formats <type> (to filter objects and typed public bound access) or <type>#<relation> (to filter usersets)") //nolint:lll
 
 	if err := listUsersCmd.MarkFlagRequired("object"); err != nil {
 		fmt.Printf("error setting flag as required - %v: %v\n", "cmd/query/list-users", err)

--- a/cmd/query/list-users.go
+++ b/cmd/query/list-users.go
@@ -1,0 +1,141 @@
+/*
+Copyright © 2023 OpenFGA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package query
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/client"
+	"github.com/spf13/cobra"
+
+	"github.com/openfga/cli/internal/cmdutils"
+	"github.com/openfga/cli/internal/output"
+)
+
+func parseUserFilters(rawUserFilter string) []openfga.UserTypeFilter {
+	userFilters := []openfga.UserTypeFilter{}
+
+	if rawUserFilter != "" {
+		if strings.Contains(rawUserFilter, "#") {
+			splitFilter := strings.Split(rawUserFilter, "#")
+			userFilters = append(userFilters, openfga.UserTypeFilter{
+				Type:     splitFilter[0],
+				Relation: &splitFilter[1],
+			})
+		} else {
+			userFilters = append(userFilters, openfga.UserTypeFilter{
+				Type: rawUserFilter,
+			})
+		}
+	}
+
+	return userFilters
+}
+
+func parseObject(rawObject string) openfga.FgaObject {
+	splitObject := strings.Split(rawObject, ":")
+
+	return openfga.FgaObject{
+		Type: splitObject[0],
+		Id:   splitObject[1],
+	}
+}
+
+func listUsers(
+	fgaClient client.SdkClient,
+	rawObject string,
+	relation string,
+	rawUserFilter string,
+	contextualTuples []client.ClientContextualTupleKey,
+	queryContext *map[string]interface{},
+) (*client.ClientListUsersResponse, error) {
+	body := &client.ClientListUsersRequest{
+		Object:           parseObject(rawObject),
+		Relation:         relation,
+		UserFilters:      parseUserFilters(rawUserFilter),
+		ContextualTuples: contextualTuples,
+		Context:          queryContext,
+	}
+	options := &client.ClientListUsersOptions{}
+
+	response, err := fgaClient.ListUsers(context.Background()).Body(*body).Options(*options).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list relations due to %w", err)
+	}
+
+	return response, nil
+}
+
+var listUsersCmd = &cobra.Command{
+	Use:     "list-users",
+	Short:   "List users",
+	Long:    "List all users that are associated with an object",
+	Example: `fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		clientConfig := cmdutils.GetClientConfig(cmd)
+		fgaClient, err := clientConfig.GetFgaClient()
+		if err != nil {
+			return fmt.Errorf("failed to initialize FGA Client due to %w", err)
+		}
+
+		contextualTuples, err := cmdutils.ParseContextualTuples(cmd)
+		if err != nil {
+			return fmt.Errorf("error parsing contextual tuples: %w", err)
+		}
+
+		queryContext, err := cmdutils.ParseQueryContext(cmd, "context")
+		if err != nil {
+			return fmt.Errorf("error parsing query context: %w", err)
+		}
+
+		userFilter, _ := cmd.Flags().GetString("user-filter")
+		object, _ := cmd.Flags().GetString("object")
+		relation, _ := cmd.Flags().GetString("relation")
+
+		response, err := listUsers(fgaClient, object, relation, userFilter, contextualTuples, queryContext)
+		if err != nil {
+			return fmt.Errorf("failed to list users due to %w", err)
+		}
+
+		return output.Display(*response)
+	},
+}
+
+func init() {
+	listUsersCmd.Flags().String("object", "", "Object to list users for")
+	listUsersCmd.Flags().String("relation", "", "Relation to search on")
+	listUsersCmd.Flags().String("user-filter", "", "Type or userset to filter to")
+
+	if err := listUsersCmd.MarkFlagRequired("object"); err != nil {
+		fmt.Printf("error setting flag as required - %v: %v\n", "cmd/query/list-users", err)
+		os.Exit(1)
+	}
+
+	if err := listUsersCmd.MarkFlagRequired("relation"); err != nil {
+		fmt.Printf("error setting flag as required - %v: %v\n", "cmd/query/list-users", err)
+		os.Exit(1)
+	}
+
+	if err := listUsersCmd.MarkFlagRequired("user-filter"); err != nil {
+		fmt.Printf("error setting flag as required - %v: %v\n", "cmd/query/list-users", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/query/list-users_test.go
+++ b/cmd/query/list-users_test.go
@@ -1,0 +1,131 @@
+package query
+
+import (
+	"context"
+	"testing"
+
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/client"
+	"go.uber.org/mock/gomock"
+
+	mock_client "github.com/openfga/cli/internal/mocks"
+)
+
+func TestListUsersSimpleType(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mock_client.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mock_client.NewMockSdkClientListUsersRequestInterface(mockCtrl)
+
+	expectedResponse := client.ClientListUsersResponse{
+		Users: []openfga.User{
+			{
+				Object: &openfga.FgaObject{
+					Type: "user",
+					Id:   "anne",
+				},
+			},
+		},
+	}
+
+	mockExecute.EXPECT().Execute().Return(&expectedResponse, nil)
+
+	mockRequest := mock_client.NewMockSdkClientListUsersRequestInterface(mockCtrl)
+	options := client.ClientListUsersOptions{}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+
+	mockBody := mock_client.NewMockSdkClientListUsersRequestInterface(mockCtrl)
+
+	contextualTuples := []client.ClientContextualTupleKey{}
+	userFilters := []openfga.UserTypeFilter{
+		{
+			Type: "user",
+		},
+	}
+
+	body := client.ClientListUsersRequest{
+		Object: openfga.FgaObject{
+			Type: "doc",
+			Id:   "doc1",
+		},
+		Relation:         "admin",
+		UserFilters:      userFilters,
+		ContextualTuples: contextualTuples,
+		Context:          queryContext,
+	}
+	mockBody.EXPECT().Body(body).Return(mockRequest)
+
+	mockFgaClient.EXPECT().ListUsers(context.Background()).Return(mockBody)
+
+	output, err := listUsers(mockFgaClient, "doc:doc1", "admin", "user", contextualTuples, queryContext)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if output != &expectedResponse {
+		t.Errorf("Expect %v but actual %v", expectedResponse, *output)
+	}
+}
+
+func TestListUsersSimpleTypeAndRelation(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mock_client.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mock_client.NewMockSdkClientListUsersRequestInterface(mockCtrl)
+
+	expectedResponse := client.ClientListUsersResponse{
+		Users: []openfga.User{
+			{
+				Object: &openfga.FgaObject{
+					Type: "user",
+					Id:   "anne",
+				},
+			},
+		},
+	}
+
+	mockExecute.EXPECT().Execute().Return(&expectedResponse, nil)
+
+	mockRequest := mock_client.NewMockSdkClientListUsersRequestInterface(mockCtrl)
+	options := client.ClientListUsersOptions{}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+
+	mockBody := mock_client.NewMockSdkClientListUsersRequestInterface(mockCtrl)
+
+	contextualTuples := []client.ClientContextualTupleKey{}
+	userFilters := []openfga.UserTypeFilter{
+		{
+			Type:     "group",
+			Relation: openfga.PtrString("member"),
+		},
+	}
+
+	body := client.ClientListUsersRequest{
+		Object: openfga.FgaObject{
+			Type: "doc",
+			Id:   "doc1",
+		},
+		Relation:         "admin",
+		UserFilters:      userFilters,
+		ContextualTuples: contextualTuples,
+		Context:          queryContext,
+	}
+	mockBody.EXPECT().Body(body).Return(mockRequest)
+
+	mockFgaClient.EXPECT().ListUsers(context.Background()).Return(mockBody)
+
+	output, err := listUsers(mockFgaClient, "doc:doc1", "admin", "group#member", contextualTuples, queryContext)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if output != &expectedResponse {
+		t.Errorf("Expect %v but actual %v", expectedResponse, *output)
+	}
+}

--- a/cmd/query/query.go
+++ b/cmd/query/query.go
@@ -28,7 +28,7 @@ import (
 var QueryCmd = &cobra.Command{
 	Use:   "query",
 	Short: "Run Queries",
-	Long:  "Run queries (Check, ListObjects, ListRelations, Expand) that are evaluated according to a particular model.",
+	Long:  "Run queries (Check, Expand, ListObjects, ListRelations, ListUsers) that are evaluated according to a particular model.", //nolint:lll
 }
 
 func init() {
@@ -36,6 +36,7 @@ func init() {
 	QueryCmd.AddCommand(expandCmd)
 	QueryCmd.AddCommand(listObjectsCmd)
 	QueryCmd.AddCommand(listRelationsCmd)
+	QueryCmd.AddCommand(listUsersCmd)
 
 	QueryCmd.PersistentFlags().String("store-id", "", "Store ID")
 	QueryCmd.PersistentFlags().String("model-id", "", "Model ID")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/nwidger/jsoncolor v0.3.2
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/openfga/api/proto v0.0.0-20240425220334-619029c1d3d3
-	github.com/openfga/go-sdk v0.3.6-0.20240415101814-23d3da979203
+	github.com/openfga/go-sdk v0.3.6-0.20240430041914-d27ef8fa20b8
 	github.com/openfga/language/pkg/go v0.0.0-20240429103126-f3e71ca3287d
 	github.com/openfga/openfga v1.5.3
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,10 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/openfga/api/proto v0.0.0-20240425220334-619029c1d3d3 h1:d1Kpom9kYMCJQlImCVHAEUfTcL4WeiEGQHcc5+KYQnk=
 github.com/openfga/api/proto v0.0.0-20240425220334-619029c1d3d3/go.mod h1:5LtWOArDX4FlbcfDvBoJAzDEYJKLz/OEUoi+0S2tyM8=
-github.com/openfga/go-sdk v0.3.6-0.20240415101814-23d3da979203 h1:PnHAJTe65PLmTwMwTrAes0LcDyTiCdH5aUwIpiQRg6Y=
-github.com/openfga/go-sdk v0.3.6-0.20240415101814-23d3da979203/go.mod h1:AoMnFlPw65sU/7O4xOPpCb2vXA8ZD9K9xp2hZjcvt4g=
+github.com/openfga/go-sdk v0.3.6-0.20240425164425-0ac2df2acad5 h1:hjhR7oRVvpKQ9kbFCcel6vAbO2nlr5nwORn80sVzuFU=
+github.com/openfga/go-sdk v0.3.6-0.20240425164425-0ac2df2acad5/go.mod h1:AoMnFlPw65sU/7O4xOPpCb2vXA8ZD9K9xp2hZjcvt4g=
+github.com/openfga/go-sdk v0.3.6-0.20240430041914-d27ef8fa20b8 h1:P2S/gfxpoHBW0tDCxu/aC67MniCcVMR6nQtNzuLLelE=
+github.com/openfga/go-sdk v0.3.6-0.20240430041914-d27ef8fa20b8/go.mod h1:t2iDiGuJtdyjvMHzkxDsbWbCWOLlVMViPKrU7Sau4K8=
 github.com/openfga/language/pkg/go v0.0.0-20240429103126-f3e71ca3287d h1:a8YgRx1RfofFiDbMj/Azwh0UeMbdfUf7OiMqSom/smQ=
 github.com/openfga/language/pkg/go v0.0.0-20240429103126-f3e71ca3287d/go.mod h1:wkI4GcY3yNNuFMU2ncHPWqBaF7XylQTkJYfBi2pIpK8=
 github.com/openfga/openfga v1.5.3 h1:Uynmlsx3iz/eiP7wW9n2dbwxDh/kiS/27W6C24Y7oyY=

--- a/internal/mocks/client.go
+++ b/internal/mocks/client.go
@@ -330,6 +330,35 @@ func (mr *MockSdkClientMockRecorder) ListStoresExecute(request any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStoresExecute", reflect.TypeOf((*MockSdkClient)(nil).ListStoresExecute), request)
 }
 
+// ListUsers mocks base method.
+func (m *MockSdkClient) ListUsers(ctx context.Context) client.SdkClientListUsersRequestInterface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListUsers", ctx)
+	ret0, _ := ret[0].(client.SdkClientListUsersRequestInterface)
+	return ret0
+}
+
+// ListUsers indicates an expected call of ListUsers.
+func (mr *MockSdkClientMockRecorder) ListUsers(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsers", reflect.TypeOf((*MockSdkClient)(nil).ListUsers), ctx)
+}
+
+// ListUsersExecute mocks base method.
+func (m *MockSdkClient) ListUsersExecute(r client.SdkClientListUsersRequestInterface) (*client.ClientListUsersResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListUsersExecute", r)
+	ret0, _ := ret[0].(*client.ClientListUsersResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListUsersExecute indicates an expected call of ListUsersExecute.
+func (mr *MockSdkClientMockRecorder) ListUsersExecute(r any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsersExecute", reflect.TypeOf((*MockSdkClient)(nil).ListUsersExecute), r)
+}
+
 // Read mocks base method.
 func (m *MockSdkClient) Read(ctx context.Context) client.SdkClientReadRequestInterface {
 	m.ctrl.T.Helper()
@@ -2520,6 +2549,128 @@ func (m *MockSdkClientListRelationsRequestInterface) Options(options client.Clie
 func (mr *MockSdkClientListRelationsRequestInterfaceMockRecorder) Options(options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Options", reflect.TypeOf((*MockSdkClientListRelationsRequestInterface)(nil).Options), options)
+}
+
+// MockSdkClientListUsersRequestInterface is a mock of SdkClientListUsersRequestInterface interface.
+type MockSdkClientListUsersRequestInterface struct {
+	ctrl     *gomock.Controller
+	recorder *MockSdkClientListUsersRequestInterfaceMockRecorder
+}
+
+// MockSdkClientListUsersRequestInterfaceMockRecorder is the mock recorder for MockSdkClientListUsersRequestInterface.
+type MockSdkClientListUsersRequestInterfaceMockRecorder struct {
+	mock *MockSdkClientListUsersRequestInterface
+}
+
+// NewMockSdkClientListUsersRequestInterface creates a new mock instance.
+func NewMockSdkClientListUsersRequestInterface(ctrl *gomock.Controller) *MockSdkClientListUsersRequestInterface {
+	mock := &MockSdkClientListUsersRequestInterface{ctrl: ctrl}
+	mock.recorder = &MockSdkClientListUsersRequestInterfaceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSdkClientListUsersRequestInterface) EXPECT() *MockSdkClientListUsersRequestInterfaceMockRecorder {
+	return m.recorder
+}
+
+// Body mocks base method.
+func (m *MockSdkClientListUsersRequestInterface) Body(body client.ClientListUsersRequest) client.SdkClientListUsersRequestInterface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Body", body)
+	ret0, _ := ret[0].(client.SdkClientListUsersRequestInterface)
+	return ret0
+}
+
+// Body indicates an expected call of Body.
+func (mr *MockSdkClientListUsersRequestInterfaceMockRecorder) Body(body any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Body", reflect.TypeOf((*MockSdkClientListUsersRequestInterface)(nil).Body), body)
+}
+
+// Execute mocks base method.
+func (m *MockSdkClientListUsersRequestInterface) Execute() (*client.ClientListUsersResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Execute")
+	ret0, _ := ret[0].(*client.ClientListUsersResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Execute indicates an expected call of Execute.
+func (mr *MockSdkClientListUsersRequestInterfaceMockRecorder) Execute() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockSdkClientListUsersRequestInterface)(nil).Execute))
+}
+
+// GetAuthorizationModelIdOverride mocks base method.
+func (m *MockSdkClientListUsersRequestInterface) GetAuthorizationModelIdOverride() *string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAuthorizationModelIdOverride")
+	ret0, _ := ret[0].(*string)
+	return ret0
+}
+
+// GetAuthorizationModelIdOverride indicates an expected call of GetAuthorizationModelIdOverride.
+func (mr *MockSdkClientListUsersRequestInterfaceMockRecorder) GetAuthorizationModelIdOverride() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationModelIdOverride", reflect.TypeOf((*MockSdkClientListUsersRequestInterface)(nil).GetAuthorizationModelIdOverride))
+}
+
+// GetBody mocks base method.
+func (m *MockSdkClientListUsersRequestInterface) GetBody() *client.ClientListUsersRequest {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBody")
+	ret0, _ := ret[0].(*client.ClientListUsersRequest)
+	return ret0
+}
+
+// GetBody indicates an expected call of GetBody.
+func (mr *MockSdkClientListUsersRequestInterfaceMockRecorder) GetBody() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBody", reflect.TypeOf((*MockSdkClientListUsersRequestInterface)(nil).GetBody))
+}
+
+// GetContext mocks base method.
+func (m *MockSdkClientListUsersRequestInterface) GetContext() context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContext")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// GetContext indicates an expected call of GetContext.
+func (mr *MockSdkClientListUsersRequestInterfaceMockRecorder) GetContext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContext", reflect.TypeOf((*MockSdkClientListUsersRequestInterface)(nil).GetContext))
+}
+
+// GetOptions mocks base method.
+func (m *MockSdkClientListUsersRequestInterface) GetOptions() *client.ClientListUsersOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOptions")
+	ret0, _ := ret[0].(*client.ClientListUsersOptions)
+	return ret0
+}
+
+// GetOptions indicates an expected call of GetOptions.
+func (mr *MockSdkClientListUsersRequestInterfaceMockRecorder) GetOptions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptions", reflect.TypeOf((*MockSdkClientListUsersRequestInterface)(nil).GetOptions))
+}
+
+// Options mocks base method.
+func (m *MockSdkClientListUsersRequestInterface) Options(options client.ClientListUsersOptions) client.SdkClientListUsersRequestInterface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Options", options)
+	ret0, _ := ret[0].(client.SdkClientListUsersRequestInterface)
+	return ret0
+}
+
+// Options indicates an expected call of Options.
+func (mr *MockSdkClientListUsersRequestInterfaceMockRecorder) Options(options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Options", reflect.TypeOf((*MockSdkClientListUsersRequestInterface)(nil).Options), options)
 }
 
 // MockSdkClientReadAssertionsRequestInterface is a mock of SdkClientReadAssertionsRequestInterface interface.


### PR DESCRIPTION
## Description

Adds support for `fga query list-users` which will call the [ListUsers](https://github.com/openfga/rfcs/blob/main/20231214-listUsers-api.md) API and return the list of users and excluded users for the stated object and relation.

There's a demo below and the command is as follows

```
# Specify a type as the filter
fga query list-users --store-id 01HWQ7ARKQ2SWXK35R2HADMDH0 --object document:1 --relation viewer --user-filter user --contextual-tuple "user:bob member group:fga-core"

# Specify a userset as the filter
fga query list-users --store-id 01HWQ7ARKQ2SWXK35R2HADMDH0 --object document:1 --relation viewer --user-filter group#member --contextual-tuple "group:fga-int#member member group:fga"

# Specify a userset as the filter and provide multiple contextual tuples
fga query list-users --store-id 01HWQ7ARKQ2SWXK35R2HADMDH0 --object document:1 --relation viewer --user-filter user --contextual-tuple "group:fga-int#member member group:fga" --contextual-tuple "user:bob member group:fga-int"
```

![fga query list users demo](https://github.com/openfga/cli/assets/8705251/0eb0fa4b-529e-4036-96b8-ae03ab6ee95c)

## References

Closes #311

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
