### PR TITLE
feat: display success/failed tuples import

### DIFF
--- a/cmd/store/.test-data/failed-store-import-001.fga.yaml
+++ b/cmd/store/.test-data/failed-store-import-001.fga.yaml
@@ -1,0 +1,23 @@
+name: FGA Demo Store
+model: |+
+  model
+    schema 1.1
+  
+  type user
+  
+  type doc
+    relations
+      define owner: [user]
+      define reader: [user]
+      define writer: [user]
+
+tuples:
+  - user: user:Kross
+    relation: writer
+    object: doc:dev-docs
+  - user: user:Modric
+    relation: owner
+    object: document:wrong-type
+tests:
+  - name: Tests
+    check: []

--- a/cmd/store/create.go
+++ b/cmd/store/create.go
@@ -32,7 +32,7 @@ import (
 )
 
 type CreateStoreAndModelResponse struct {
-	Store client.ClientCreateStoreResponse              `json:"store"`
+	Store *client.ClientCreateStoreResponse             `json:"store"`
 	Model *client.ClientWriteAuthorizationModelResponse `json:"model,omitempty"`
 }
 
@@ -69,7 +69,7 @@ func CreateStoreWithModel(
 		return nil, err
 	}
 
-	response.Store = *createStoreResponse
+	response.Store = createStoreResponse
 	fgaClient.SetStoreId(response.Store.Id)
 
 	if inputModel != "" {

--- a/cmd/store/create.go
+++ b/cmd/store/create.go
@@ -32,7 +32,7 @@ import (
 )
 
 type CreateStoreAndModelResponse struct {
-	Store *client.ClientCreateStoreResponse             `json:"store"`
+	Store *client.ClientCreateStoreResponse             `json:"store,omitempty"`
 	Model *client.ClientWriteAuthorizationModelResponse `json:"model,omitempty"`
 }
 

--- a/cmd/store/import.go
+++ b/cmd/store/import.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openfga/cli/internal/storetest"
 )
 
+// importStoreIODependencies defines IO dependencies for importing store
 type importStoreIODependencies struct {
 	createStoreWithModel func(
 		clientConfig fga.ClientConfig,

--- a/cmd/store/import_test.go
+++ b/cmd/store/import_test.go
@@ -14,18 +14,22 @@ import (
 )
 
 func TestImportStore(t *testing.T) {
-	t.Run("Must create store and modelID when there's no store configured", func(t *testing.T) {
-		// Arrange
+	t.Run("Must create store and modelID when "+
+		"there's no store configured", func(t *testing.T) {
+		t.Parallel()
+
 		clientConfig := fga.ClientConfig{ApiUrl: "https://localhost:8080"}
 		storeData := &storetest.StoreData{}
-		authorizationModelID := "01HWJGBQQNNQATBQ661SH6585Y"
+		authorizationModelID := "01HWJGBQQNNQATBQ661SH6585Y001"
 		storeID := "Test-001"
 
 		ioAggregator := importStoreIODependencies{
-			importTuples: func(fgaClient client.SdkClient, body client.ClientWriteRequest, maxTuplesPerWrite, maxParallelRequests int) (*tuple.ImportResponse, error) {
-				return nil, nil
+			importTuples: func(_ client.SdkClient, _ client.ClientWriteRequest, _, _ int,
+			) (*tuple.ImportResponse, error) {
+				return &tuple.ImportResponse{}, nil
 			},
-			createStoreWithModel: func(clientConfig fga.ClientConfig, storeName, inputModel string, inputFormat authorizationmodel.ModelFormat) (*CreateStoreAndModelResponse, error) {
+			createStoreWithModel: func(_ fga.ClientConfig, _, _ string, _ authorizationmodel.ModelFormat,
+			) (*CreateStoreAndModelResponse, error) {
 				return &CreateStoreAndModelResponse{
 					Store: &client.ClientCreateStoreResponse{
 						Id:        "01HWJGBQQHZZJHQEQZ6MCBC3B0",
@@ -40,36 +44,48 @@ func TestImportStore(t *testing.T) {
 			},
 		}
 
-		// Act
-		response, err := importStore(clientConfig, storeData, "", "", 2, 2, ioAggregator)
-
+		response, err := importStore(clientConfig,
+			storeData,
+			"",
+			"",
+			2,
+			2,
+			ioAggregator,
+		)
 		// Assert
 		if err != nil {
 			t.Error(err)
 		}
+
 		if response.Model.AuthorizationModelId != authorizationModelID {
 			t.Fatalf("expected: %s\nreturned: %s", authorizationModelID, response.Model.AuthorizationModelId)
 		}
+
 		if response.Store.Name != storeID {
 			t.Fatalf("expected: %s\nreturned: %s", storeID, response.Store.Name)
 		}
 	})
 
-	t.Run("Must return the Model ID and an empty Store when importing into an existing store", func(t *testing.T) {
+	t.Run("Must return the Model ID and an empty Store "+
+		"when importing into an existing store", func(t *testing.T) {
+		t.Parallel()
+
 		clientConfig := fga.ClientConfig{ApiUrl: "https://localhost:8080"}
 		storeData := &storetest.StoreData{}
-		authorizationModelID := "01HWJGBQQNNQATBQ661SH6585Y"
+		authorizationModelID := "01HWJGBQQNNQATBQ661SH6585Y002"
 
 		ioAggregator := importStoreIODependencies{
-			importTuples: func(fgaClient client.SdkClient, body client.ClientWriteRequest, maxTuplesPerWrite, maxParallelRequests int) (*tuple.ImportResponse, error) {
-				return nil, nil
+			importTuples: func(_ client.SdkClient, _ client.ClientWriteRequest, _, _ int,
+			) (*tuple.ImportResponse, error) {
+				return &tuple.ImportResponse{}, nil
 			},
-			modelWrite: func(fgaClient client.SdkClient, inputModel authorizationmodel.AuthzModel) (*client.ClientWriteAuthorizationModelResponse, error) {
+			modelWrite: func(_ client.SdkClient, _ authorizationmodel.AuthzModel) (*client.ClientWriteAuthorizationModelResponse, error) {
 				return &client.ClientWriteAuthorizationModelResponse{
 					AuthorizationModelId: authorizationModelID,
 				}, nil
 			},
-			createStoreWithModel: func(clientConfig fga.ClientConfig, storeName, inputModel string, inputFormat authorizationmodel.ModelFormat) (*CreateStoreAndModelResponse, error) {
+			createStoreWithModel: func(_ fga.ClientConfig, _, _ string, _ authorizationmodel.ModelFormat,
+			) (*CreateStoreAndModelResponse, error) {
 				return &CreateStoreAndModelResponse{
 					Model: &client.ClientWriteAuthorizationModelResponse{
 						AuthorizationModelId: authorizationModelID,
@@ -78,26 +94,36 @@ func TestImportStore(t *testing.T) {
 			},
 		}
 
-		// Act
-		response, err := importStore(clientConfig, storeData, "", "01HWJGBQQHZZJHQEQZ6MCBC3B0", 2, 2, ioAggregator)
-
+		response, err := importStore(clientConfig,
+			storeData, "",
+			"01HWJGBQQHZZJHQEQZ6MCBC3B0",
+			2,
+			2,
+			ioAggregator,
+		)
 		// Assert
 		if err != nil {
 			t.Error(err)
 		}
+
 		if response.Store != nil {
 			t.Fatalf("Expected: null\nReturn: %v", response.Store)
 		}
+
 		if response.Model.AuthorizationModelId != authorizationModelID {
 			t.Fatalf("expected: %s\nreturned: %s", authorizationModelID, response.Model.AuthorizationModelId)
 		}
 	})
 
-	t.Run("Must returns the modelID, a null store object, and a list of failed/successfully imported tuples when tuples containing unregistered types are provided as input", func(t *testing.T) {
+	t.Run("Must returns the modelID, a null store object, and a list of "+
+		"failed/successfully imported tuples when tuples containing unregistered "+
+		"types are provided as input", func(t *testing.T) {
+		t.Parallel()
+
 		clientConfig := fga.ClientConfig{ApiUrl: "https://localhost:8080"}
 		fileName := "./.test-data/failed-store-import-001.fga.yaml"
-		format, storeData, err := storetest.ReadFromFile(fileName, path.Dir(fileName))
-		authorizationModelID := "01HWJGBQQNNQATBQ661SH6585Y"
+		format, storeData, _ := storetest.ReadFromFile(fileName, path.Dir(fileName))
+		authorizationModelID := "01HWJGBQQNNQATBQ661SH6585Y003"
 
 		successfulTupleImport := storeData.Tuples[0]
 		failedTupleImport := storeData.Tuples[1]
@@ -107,7 +133,10 @@ func TestImportStore(t *testing.T) {
 			failedTupleImport.User,
 		)
 		ioAggregator := importStoreIODependencies{
-			importTuples: func(fgaClient client.SdkClient, body client.ClientWriteRequest, maxTuplesPerWrite, maxParallelRequests int) (*tuple.ImportResponse, error) {
+			importTuples: func(_ client.SdkClient,
+				_ client.ClientWriteRequest, _,
+				_ int,
+			) (*tuple.ImportResponse, error) {
 				return &tuple.ImportResponse{
 					Successful: []client.ClientTupleKey{
 						successfulTupleImport,
@@ -120,12 +149,19 @@ func TestImportStore(t *testing.T) {
 					},
 				}, nil
 			},
-			modelWrite: func(fgaClient client.SdkClient, inputModel authorizationmodel.AuthzModel) (*client.ClientWriteAuthorizationModelResponse, error) {
+			modelWrite: func(
+				_ client.SdkClient,
+				_ authorizationmodel.AuthzModel,
+			) (*client.ClientWriteAuthorizationModelResponse, error) {
 				return &client.ClientWriteAuthorizationModelResponse{
 					AuthorizationModelId: authorizationModelID,
 				}, nil
 			},
-			createStoreWithModel: func(clientConfig fga.ClientConfig, storeName, inputModel string, inputFormat authorizationmodel.ModelFormat) (*CreateStoreAndModelResponse, error) {
+			createStoreWithModel: func(_ fga.ClientConfig,
+				_,
+				_ string,
+				_ authorizationmodel.ModelFormat,
+			) (*CreateStoreAndModelResponse, error) {
 				return &CreateStoreAndModelResponse{
 					Model: &client.ClientWriteAuthorizationModelResponse{
 						AuthorizationModelId: authorizationModelID,
@@ -135,22 +171,34 @@ func TestImportStore(t *testing.T) {
 		}
 
 		// Act
-		importResponse, err := importStore(clientConfig, storeData, format, "01HWJGBQQHZZJHQEQZ6MCBC3B0", 2, 2, ioAggregator)
+		importResponse, err := importStore(clientConfig,
+			storeData,
+			format,
+			"01HWJGBQQHZZJHQEQZ6MCBC3B0",
+			2,
+			2,
+			ioAggregator,
+		)
 		if err != nil {
 			t.Error(err)
 		}
+
 		if len(importResponse.Tuple.Successful) != 1 {
 			t.Fatalf("expected: %d\nreturned: %d", 1, len(importResponse.Tuple.Successful))
 		}
+
 		if len(importResponse.Tuple.Failed) != 1 {
 			t.Fatalf("expected: %d\nreturned: %d", 1, len(importResponse.Tuple.Failed))
 		}
+
 		if !reflect.DeepEqual(importResponse.Tuple.Successful[0], successfulTupleImport) {
 			t.Fatalf("expected: %v\nreturned: %v", successfulTupleImport, importResponse.Tuple.Successful[0])
 		}
+
 		if !reflect.DeepEqual(importResponse.Tuple.Failed[0].TupleKey, failedTupleImport) {
 			t.Fatalf("expected: %v\nreturned: %v", failedTupleImport, importResponse.Tuple.Failed[0])
 		}
+
 		if failureReason != importResponse.Tuple.Failed[0].Reason {
 			t.Fatalf("expected: %s\nreturned: %s", failureReason, importResponse.Tuple.Failed[0].Reason)
 		}

--- a/cmd/store/import_test.go
+++ b/cmd/store/import_test.go
@@ -1,0 +1,158 @@
+package store
+
+import (
+	"fmt"
+	"github.com/openfga/cli/cmd/tuple"
+	"github.com/openfga/cli/internal/authorizationmodel"
+	"github.com/openfga/cli/internal/fga"
+	"github.com/openfga/cli/internal/storetest"
+	"github.com/openfga/go-sdk/client"
+	"path"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestImportStore(t *testing.T) {
+	t.Run("Must create store and modelID when there's no store configured", func(t *testing.T) {
+		// Arrange
+		clientConfig := fga.ClientConfig{ApiUrl: "https://localhost:8080"}
+		storeData := &storetest.StoreData{}
+		authorizationModelID := "01HWJGBQQNNQATBQ661SH6585Y"
+		storeID := "Test-001"
+
+		ioAggregator := importStoreIODependencies{
+			importTuples: func(fgaClient client.SdkClient, body client.ClientWriteRequest, maxTuplesPerWrite, maxParallelRequests int) (*tuple.ImportResponse, error) {
+				return nil, nil
+			},
+			createStoreWithModel: func(clientConfig fga.ClientConfig, storeName, inputModel string, inputFormat authorizationmodel.ModelFormat) (*CreateStoreAndModelResponse, error) {
+				return &CreateStoreAndModelResponse{
+					Store: &client.ClientCreateStoreResponse{
+						Id:        "01HWJGBQQHZZJHQEQZ6MCBC3B0",
+						Name:      storeID,
+						CreatedAt: time.Now(),
+						UpdatedAt: time.Now(),
+					},
+					Model: &client.ClientWriteAuthorizationModelResponse{
+						AuthorizationModelId: authorizationModelID,
+					},
+				}, nil
+			},
+		}
+
+		// Act
+		response, err := importStore(clientConfig, storeData, "", "", 2, 2, ioAggregator)
+
+		// Assert
+		if err != nil {
+			t.Error(err)
+		}
+		if response.Model.AuthorizationModelId != authorizationModelID {
+			t.Fatalf("expected: %s\nreturned: %s", authorizationModelID, response.Model.AuthorizationModelId)
+		}
+		if response.Store.Name != storeID {
+			t.Fatalf("expected: %s\nreturned: %s", storeID, response.Store.Name)
+		}
+	})
+
+	t.Run("Must return the Model ID and an empty Store when importing into an existing store", func(t *testing.T) {
+		clientConfig := fga.ClientConfig{ApiUrl: "https://localhost:8080"}
+		storeData := &storetest.StoreData{}
+		authorizationModelID := "01HWJGBQQNNQATBQ661SH6585Y"
+
+		ioAggregator := importStoreIODependencies{
+			importTuples: func(fgaClient client.SdkClient, body client.ClientWriteRequest, maxTuplesPerWrite, maxParallelRequests int) (*tuple.ImportResponse, error) {
+				return nil, nil
+			},
+			modelWrite: func(fgaClient client.SdkClient, inputModel authorizationmodel.AuthzModel) (*client.ClientWriteAuthorizationModelResponse, error) {
+				return &client.ClientWriteAuthorizationModelResponse{
+					AuthorizationModelId: authorizationModelID,
+				}, nil
+			},
+			createStoreWithModel: func(clientConfig fga.ClientConfig, storeName, inputModel string, inputFormat authorizationmodel.ModelFormat) (*CreateStoreAndModelResponse, error) {
+				return &CreateStoreAndModelResponse{
+					Model: &client.ClientWriteAuthorizationModelResponse{
+						AuthorizationModelId: authorizationModelID,
+					},
+				}, nil
+			},
+		}
+
+		// Act
+		response, err := importStore(clientConfig, storeData, "", "01HWJGBQQHZZJHQEQZ6MCBC3B0", 2, 2, ioAggregator)
+
+		// Assert
+		if err != nil {
+			t.Error(err)
+		}
+		if response.Store != nil {
+			t.Fatalf("Expected: null\nReturn: %v", response.Store)
+		}
+		if response.Model.AuthorizationModelId != authorizationModelID {
+			t.Fatalf("expected: %s\nreturned: %s", authorizationModelID, response.Model.AuthorizationModelId)
+		}
+	})
+
+	t.Run("Must returns the modelID, a null store object, and a list of failed/successfully imported tuples when tuples containing unregistered types are provided as input", func(t *testing.T) {
+		clientConfig := fga.ClientConfig{ApiUrl: "https://localhost:8080"}
+		fileName := "./.test-data/failed-store-import-001.fga.yaml"
+		format, storeData, err := storetest.ReadFromFile(fileName, path.Dir(fileName))
+		authorizationModelID := "01HWJGBQQNNQATBQ661SH6585Y"
+
+		successfulTupleImport := storeData.Tuples[0]
+		failedTupleImport := storeData.Tuples[1]
+		failureReason := fmt.Sprintf("error message: Invalid tuple '%s#%s@%s'. Reason: type 'document' not found",
+			failedTupleImport.Object,
+			failedTupleImport.Relation,
+			failedTupleImport.User,
+		)
+		ioAggregator := importStoreIODependencies{
+			importTuples: func(fgaClient client.SdkClient, body client.ClientWriteRequest, maxTuplesPerWrite, maxParallelRequests int) (*tuple.ImportResponse, error) {
+				return &tuple.ImportResponse{
+					Successful: []client.ClientTupleKey{
+						successfulTupleImport,
+					},
+					Failed: []tuple.FailedWriteResponse{
+						{
+							TupleKey: failedTupleImport,
+							Reason:   failureReason,
+						},
+					},
+				}, nil
+			},
+			modelWrite: func(fgaClient client.SdkClient, inputModel authorizationmodel.AuthzModel) (*client.ClientWriteAuthorizationModelResponse, error) {
+				return &client.ClientWriteAuthorizationModelResponse{
+					AuthorizationModelId: authorizationModelID,
+				}, nil
+			},
+			createStoreWithModel: func(clientConfig fga.ClientConfig, storeName, inputModel string, inputFormat authorizationmodel.ModelFormat) (*CreateStoreAndModelResponse, error) {
+				return &CreateStoreAndModelResponse{
+					Model: &client.ClientWriteAuthorizationModelResponse{
+						AuthorizationModelId: authorizationModelID,
+					},
+				}, nil
+			},
+		}
+
+		// Act
+		importResponse, err := importStore(clientConfig, storeData, format, "01HWJGBQQHZZJHQEQZ6MCBC3B0", 2, 2, ioAggregator)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(importResponse.Tuple.Successful) != 1 {
+			t.Fatalf("expected: %d\nreturned: %d", 1, len(importResponse.Tuple.Successful))
+		}
+		if len(importResponse.Tuple.Failed) != 1 {
+			t.Fatalf("expected: %d\nreturned: %d", 1, len(importResponse.Tuple.Failed))
+		}
+		if !reflect.DeepEqual(importResponse.Tuple.Successful[0], successfulTupleImport) {
+			t.Fatalf("expected: %v\nreturned: %v", successfulTupleImport, importResponse.Tuple.Successful[0])
+		}
+		if !reflect.DeepEqual(importResponse.Tuple.Failed[0].TupleKey, failedTupleImport) {
+			t.Fatalf("expected: %v\nreturned: %v", failedTupleImport, importResponse.Tuple.Failed[0])
+		}
+		if failureReason != importResponse.Tuple.Failed[0].Reason {
+			t.Fatalf("expected: %s\nreturned: %s", failureReason, importResponse.Tuple.Failed[0].Reason)
+		}
+	})
+}

--- a/cmd/tuple/import.go
+++ b/cmd/tuple/import.go
@@ -37,14 +37,14 @@ var MaxTuplesPerWrite = 1
 // MaxParallelRequests Limit the parallel writes to the API.
 var MaxParallelRequests = 10
 
-type failedWriteResponse struct {
+type FailedWriteResponse struct {
 	TupleKey client.ClientTupleKey `json:"tuple_key"`
 	Reason   string                `json:"reason"`
 }
 
 type ImportResponse struct {
-	Successful []client.ClientTupleKey `json:"successful"`
-	Failed     []failedWriteResponse   `json:"failed"`
+	Successful []client.ClientTupleKey `json:"successful,omitemptys"`
+	Failed     []FailedWriteResponse   `json:"failed,omitempty"`
 }
 
 // ImportTuples receives a client.ClientWriteRequest and imports the tuples to the store. It can be used to import
@@ -98,10 +98,10 @@ func extractErrMssg(err error) string {
 
 func processWrites(
 	writes []client.ClientWriteRequestWriteResponse,
-) ([]client.ClientTupleKey, []failedWriteResponse) {
+) ([]client.ClientTupleKey, []FailedWriteResponse) {
 	var (
 		successfulWrites []client.ClientTupleKey
-		failedWrites     []failedWriteResponse
+		failedWrites     []FailedWriteResponse
 	)
 
 	for _, write := range writes {
@@ -109,7 +109,7 @@ func processWrites(
 			successfulWrites = append(successfulWrites, write.TupleKey)
 		} else {
 			reason := extractErrMssg(write.Error)
-			failedWrites = append(failedWrites, failedWriteResponse{
+			failedWrites = append(failedWrites, FailedWriteResponse{
 				TupleKey: write.TupleKey,
 				Reason:   reason,
 			})
@@ -121,10 +121,10 @@ func processWrites(
 
 func processDeletes(
 	deletes []client.ClientWriteRequestDeleteResponse,
-) ([]client.ClientTupleKey, []failedWriteResponse) {
+) ([]client.ClientTupleKey, []FailedWriteResponse) {
 	var (
 		successfulDeletes []client.ClientTupleKey
-		failedDeletes     []failedWriteResponse
+		failedDeletes     []FailedWriteResponse
 	)
 
 	for _, delete := range deletes {
@@ -138,7 +138,7 @@ func processDeletes(
 			successfulDeletes = append(successfulDeletes, deletedTupleKey)
 		} else {
 			reason := extractErrMssg(delete.Error)
-			failedDeletes = append(failedDeletes, failedWriteResponse{
+			failedDeletes = append(failedDeletes, FailedWriteResponse{
 				TupleKey: deletedTupleKey,
 				Reason:   reason,
 			})

--- a/cmd/tuple/import.go
+++ b/cmd/tuple/import.go
@@ -43,7 +43,7 @@ type FailedWriteResponse struct {
 }
 
 type ImportResponse struct {
-	Successful []client.ClientTupleKey `json:"successful,omitemptys"`
+	Successful []client.ClientTupleKey `json:"successful,omitempty"`
 	Failed     []FailedWriteResponse   `json:"failed,omitempty"`
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Closes #259 

- Enhance store import functionality testability
- Suppress store object display when store ID is provided in command

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ x] The correct base branch is being used, if not `main`
- [ x] I have added tests to validate that the change in functionality is working as expected
