### PR TITLE
build: replace gomnd with mnd

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,6 +24,7 @@ linters:
     - nosnakecase
     - testpackage
     - gci
+    - gomnd
 linters-settings:
   depguard:
     rules:

--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -74,7 +74,7 @@ func validate(inputModel authorizationmodel.AuthzModel) validationResult {
 			return output
 		}
 
-		createdAt := time.Unix(int64(modelID.Time()/1_000), 0).UTC() //nolint:gomnd
+		createdAt := time.Unix(int64(modelID.Time()/1_000), 0).UTC() //nolint:mnd
 		output.CreatedAt = &createdAt
 	}
 

--- a/cmd/query/check.go
+++ b/cmd/query/check.go
@@ -58,7 +58,7 @@ var checkCmd = &cobra.Command{
 	Short:   "Check",
 	Example: `fga query check --store-id="01H4P8Z95KTXXEP6Z03T75Q984" user:anne can_view document:roadmap --context '{"ip_address":"127.0.0.1"}'`, //nolint:lll
 	Long:    "Check if a user has a particular relation with an object.",
-	Args:    cobra.ExactArgs(3), //nolint:gomnd
+	Args:    cobra.ExactArgs(3), //nolint:mnd
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 		fgaClient, err := clientConfig.GetFgaClient()

--- a/cmd/query/expand.go
+++ b/cmd/query/expand.go
@@ -47,7 +47,7 @@ var expandCmd = &cobra.Command{
 	Short:   "Expand",
 	Long:    "Expands the relationships in userset tree format.",
 	Example: `fga query expand --store-id="01H4P8Z95KTXXEP6Z03T75Q984" can_view document:roadmap`,
-	Args:    cobra.ExactArgs(2), //nolint:gomnd
+	Args:    cobra.ExactArgs(2), //nolint:mnd
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 

--- a/cmd/query/list-objects.go
+++ b/cmd/query/list-objects.go
@@ -59,7 +59,7 @@ var listObjectsCmd = &cobra.Command{
 	Short:   "List Objects",
 	Long:    "List the objects of a certain type that a user has a particular relation to.",
 	Example: `fga query list-objects --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne can_view document --contextual-tuple "user:anne can_view folder:product" --contextual-tuple "folder:product parent document:roadmap"`, //nolint:lll
-	Args:    cobra.ExactArgs(3),                                                                                                                                                                                            //nolint:gomnd,lll
+	Args:    cobra.ExactArgs(3),                                                                                                                                                                                            //nolint:mnd,lll
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 

--- a/cmd/query/list-relations.go
+++ b/cmd/query/list-relations.go
@@ -122,7 +122,7 @@ var listRelationsCmd = &cobra.Command{
 	Short:   "List Relations",
 	Long:    "List relations that a user has with an object.",
 	Example: `fga query list-relations --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne document:roadmap --relation can_view`, //nolint:lll
-	Args:    cobra.ExactArgs(2),                                                                                              //nolint:gomnd,lll
+	Args:    cobra.ExactArgs(2),                                                                                              //nolint:mnd,lll
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 		fgaClient, err := clientConfig.GetFgaClient()

--- a/cmd/store/export.go
+++ b/cmd/store/export.go
@@ -175,7 +175,7 @@ var exportCmd = &cobra.Command{
 				}
 			}
 
-			err = os.WriteFile(fileName, storeYaml, 0o600) //nolint:gomnd
+			err = os.WriteFile(fileName, storeYaml, 0o600) //nolint:mnd
 			if err != nil {
 				return err //nolint:wrapcheck
 			}

--- a/cmd/tuple/delete.go
+++ b/cmd/tuple/delete.go
@@ -33,7 +33,7 @@ import (
 var deleteCmd = &cobra.Command{
 	Use:     "delete",
 	Short:   "Delete Relationship Tuples",
-	Args:    ExactArgsOrFlag(3, "file"), //nolint:gomnd
+	Args:    ExactArgsOrFlag(3, "file"), //nolint:mnd
 	Long:    "Delete relationship tuples from the store.",
 	Example: "fga tuple delete --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne can_view document:roadmap",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/authorizationmodel/model.go
+++ b/internal/authorizationmodel/model.go
@@ -39,7 +39,7 @@ func getCreatedAtFromModelID(id string) (*time.Time, error) {
 		return nil, fmt.Errorf("error parsing model id %w", err)
 	}
 
-	createdAt := time.Unix(int64(modelID.Time()/1_000), 0).UTC() //nolint:gomnd
+	createdAt := time.Unix(int64(modelID.Time()/1_000), 0).UTC() //nolint:mnd
 
 	return &createdAt, nil
 }
@@ -286,7 +286,7 @@ func (model *AuthzModel) setCreatedAt() {
 	if *model.ID != "" {
 		modelID, err := ulid.Parse(*model.ID)
 		if err == nil {
-			createdAt := time.Unix(int64(modelID.Time()/1_000), 0).UTC() //nolint:gomnd
+			createdAt := time.Unix(int64(modelID.Time()/1_000), 0).UTC() //nolint:mnd
 			model.CreatedAt = &createdAt
 		}
 	}

--- a/internal/cmdutils/get-contextual-tuples.go
+++ b/internal/cmdutils/get-contextual-tuples.go
@@ -44,7 +44,7 @@ func ParseContextualTuplesInner(contextualTuplesArray []string) ([]client.Client
 
 			var condition *openfga.RelationshipCondition
 
-			if len(tuple) == 4 { //nolint:gomnd
+			if len(tuple) == 4 { //nolint:mnd
 				cond, err := ParseTupleConditionString(tuple[3])
 				if err != nil {
 					return nil, fmt.Errorf("failed to parse condition due to %w", err)


### PR DESCRIPTION
## Description

Latest version of golangci deprecated the `gomnd` linter and replaced it with `mnd`, so disable `gomnd` (as it's still in the default set) and replace with `mnd`

## References

https://github.com/openfga/cli/actions/runs/8969453051/job/24630885443?pr=322

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
