### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### [0.4.0](https://github.com/openfga/cli/compare/v0.3.1...v0.4.0) (2024-05-07)
+
+Added:
+- Support querying the [list users API](https://openfga.dev/blog/list-users-announcement) with `fga query list-users` (#314)
+- Support for running list users tests via `fga model test` (#315)
+
+Changed:
+- `fga store import` now uses the filename if no name is provided (#318) - thanks @NeerajNagure
+
 ### [0.3.1](https://github.com/openfga/cli/compare/v0.3.0...v0.3.1) (2024-04-29)
 
 Added:


### PR DESCRIPTION
## Description

Added:
- Support querying the [list users API](https://openfga.dev/blog/list-users-announcement) with `fga query list-users` (#314)
- Support for running list users tests via `fga model test` (#315)

Changed:
- `fga store import` now uses the filename if no name is provided (#318)


## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
