### PR TITLE
release: v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### [0.4.1](https://github.com/openfga/cli/compare/v0.4.0...v0.4.1) (2024-06-05)
+
+Added:
+- Support asserting the `excluded_users` in `list_users` tests (#337)
+
+Fixed:
+- `fga store import` now outputs store and model details when writing to an existing store (#336)
+
 ### [0.4.0](https://github.com/openfga/cli/compare/v0.3.1...v0.4.0) (2024-05-07)
 
 Added:


### PR DESCRIPTION
## Description

```
### [0.4.1](https://github.com/openfga/cli/compare/v0.4.0...v0.4.1) (2024-06-05)

Added:
- Support asserting the `excluded_users` in `list_users` tests (#337)

Fixed:
- `fga store import` now outputs store and model details when writing to an existing store (#336)
```


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
