### PR TITLE
ci: move to using goreleaser v2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -114,11 +114,11 @@ jobs:
     - uses: anchore/sbom-action/download-syft@e8d2a6937ecead383dfe75190d104edd1f9c5751 # v0.16.0
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
+      uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
       with:
         distribution: goreleaser
-        version: latest
-        args: release --clean --config .goreleaser.yaml --snapshot --skip-sign --skip-publish --skip-announce
+        version: '~> v2'
+        args: release --clean --config .goreleaser.yaml --snapshot --skip sign,publish,announce
 
   goreleaser:
     runs-on: ubuntu-latest
@@ -161,10 +161,10 @@ jobs:
 
       - name: Run GoReleaser
         id: goreleaser
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --clean --config .goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: fga
 
 before:
@@ -126,7 +128,7 @@ brews:
     homepage: "https://openfga.dev/"
     description: "A cross-platform CLI to interact with an OpenFGA server."
     license: "Apache-2.0"
-    folder: "Formula"
+    directory: "Formula"
     url_template: "https://github.com/openfga/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     download_strategy: CurlDownloadStrategy
 
@@ -152,7 +154,7 @@ brews:
     homepage: "https://openfga.dev/"
     description: "A cross-platform CLI to interact with an OpenFGA server."
     license: "Apache-2.0"
-    folder: "Formula"
+    directory: "Formula"
     url_template: "https://github.com/openfga/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     download_strategy: CurlDownloadStrategy
 


### PR DESCRIPTION
## Description

The deprecations we had were the [brew.folder](https://goreleaser.com/deprecations/#brewsfolder) property, renamed to directory and the [usage of --skip-<value> flags](https://goreleaser.com/deprecations/#-skip) which are replaced by a single --skip flag that accepts the values to skip


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
