### PR TITLE
Removing excluded users from ListUsers response

### DIFF
--- a/README.md
+++ b/README.md
@@ -1100,14 +1100,6 @@ fga query **list-users** --object <object> --relation <relation> --user-filter <
 ```json5
 {
     {
-      "excluded_users": [
-        {
-          "object": {
-            "type": "user",
-            "id": "beth"
-          }
-        }
-      ],
       "users": [
         {
           "object": {

--- a/example/model.fga.yaml
+++ b/example/model.fga.yaml
@@ -78,8 +78,6 @@ tests:
             users:
               - user:anne
               - user:beth
-            excluded_users: []
           can_write:
             users:
               - user:anne
-            excluded_users: []

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/nwidger/jsoncolor v0.3.2
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/openfga/api/proto v0.0.0-20240529190005-394820dfc109
-	github.com/openfga/go-sdk v0.4.0
+	github.com/openfga/go-sdk v0.5.0
 	github.com/openfga/language/pkg/go v0.0.0-20240530090832-1ae482acc202
 	github.com/openfga/openfga v1.5.4
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/openfga/api/proto v0.0.0-20240529190005-394820dfc109 h1:V92DXyx43GBjLCv4Ky/u2jT8Lr1Hc3g8wNbnDHBfdBM=
 github.com/openfga/api/proto v0.0.0-20240529190005-394820dfc109/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
-github.com/openfga/go-sdk v0.4.0 h1:C7h/x7Yq3NjxThHE4YGz+rwfawmyo8d9SVScer8fB9w=
-github.com/openfga/go-sdk v0.4.0/go.mod h1:AoMnFlPw65sU/7O4xOPpCb2vXA8ZD9K9xp2hZjcvt4g=
+github.com/openfga/go-sdk v0.5.0 h1:1IuAu6Xf4eBxgc2AyMfosK7QzApxuZ5yi7jmFaftnl0=
+github.com/openfga/go-sdk v0.5.0/go.mod h1:AoMnFlPw65sU/7O4xOPpCb2vXA8ZD9K9xp2hZjcvt4g=
 github.com/openfga/language/pkg/go v0.0.0-20240530090832-1ae482acc202 h1:DkW3VX6wOMckk2VIeaafdKW1WOt5Se6d/7L9239tt6I=
 github.com/openfga/language/pkg/go v0.0.0-20240530090832-1ae482acc202/go.mod h1:mCwEY2IQvyNgfEwbfH0C0ERUwtL8z6UjSAF8zgn5Xbg=
 github.com/openfga/openfga v1.5.4 h1:mVrp0uB9jNWX/5+OtZLM6YOx5Y9Y4r/D/O+LNBF/FGQ=

--- a/internal/storetest/conversion.go
+++ b/internal/storetest/conversion.go
@@ -106,18 +106,3 @@ func convertOpenfgaUsers(users []openfga.User) []string {
 
 	return simpleUsers
 }
-
-func convertOpenfgaObjectOrUserset(users []openfga.ObjectOrUserset) []string {
-	simpleUsers := []string{}
-
-	for _, user := range users {
-		switch {
-		case user.Object != nil:
-			simpleUsers = append(simpleUsers, user.Object.Type+":"+user.Object.Id)
-		case user.Userset != nil:
-			simpleUsers = append(simpleUsers, user.Userset.Type+":"+user.Userset.Id+"#"+user.Userset.Relation)
-		}
-	}
-
-	return simpleUsers
-}

--- a/internal/storetest/conversion_test.go
+++ b/internal/storetest/conversion_test.go
@@ -172,31 +172,3 @@ func TestConvertPbObjectOrUsersetToStrings(t *testing.T) {
 		})
 	}
 }
-
-func TestConvertObjectOrUsersetToStrings(t *testing.T) {
-	t.Parallel()
-
-	tests := map[string]struct {
-		input    openfga.ObjectOrUserset
-		expected string
-	}{
-		"User_Object": {
-			input:    openfga.ObjectOrUserset{Object: &openfga.FgaObject{Type: "user", Id: "anne"}},
-			expected: "user:anne",
-		},
-		"User_Userset": {
-			input:    openfga.ObjectOrUserset{Userset: &openfga.UsersetUser{Type: "group", Id: "fga", Relation: "member"}},
-			expected: "group:fga#member",
-		},
-	}
-
-	for name, testcase := range tests {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			got := convertOpenfgaObjectOrUserset([]openfga.ObjectOrUserset{testcase.input})
-
-			assert.Equal(t, []string{testcase.expected}, got)
-		})
-	}
-}

--- a/internal/storetest/localtest.go
+++ b/internal/storetest/localtest.go
@@ -205,8 +205,7 @@ func RunLocalListUsersTest(
 
 			if response != nil {
 				result.Got = ModelTestListUsersAssertion{
-					Users:         convertPbUsersToStrings(response.GetUsers()),
-					ExcludedUsers: convertPbObjectOrUsersetToStrings(response.GetExcludedUsers()),
+					Users: convertPbUsersToStrings(response.GetUsers()),
 				}
 				result.TestResult = result.IsPassing()
 			}

--- a/internal/storetest/remotetest.go
+++ b/internal/storetest/remotetest.go
@@ -112,8 +112,7 @@ func RunSingleRemoteListUsersTest(
 
 	if response != nil {
 		result.Got = ModelTestListUsersAssertion{
-			Users:         convertOpenfgaUsers(response.GetUsers()),
-			ExcludedUsers: convertOpenfgaObjectOrUserset(response.GetExcludedUsers()),
+			Users: convertOpenfgaUsers(response.GetUsers()),
 		}
 		result.TestResult = result.IsPassing()
 	}

--- a/internal/storetest/storedata.go
+++ b/internal/storetest/storedata.go
@@ -51,8 +51,7 @@ type ModelTestListUsers struct {
 }
 
 type ModelTestListUsersAssertion struct {
-	Users         []string `json:"users"          yaml:"users"`
-	ExcludedUsers []string `json:"excluded_users" yaml:"excluded_users"` //nolint:tagliatelle
+	Users []string `json:"users" yaml:"users"`
 }
 
 type ModelTest struct {

--- a/internal/storetest/testresult.go
+++ b/internal/storetest/testresult.go
@@ -46,8 +46,7 @@ type ModelTestListUsersSingleResult struct {
 
 func (result ModelTestListUsersSingleResult) IsPassing() bool {
 	return result.Error == nil &&
-		comparison.CheckStringArraysEqual(result.Got.Users, result.Expected.Users) &&
-		comparison.CheckStringArraysEqual(result.Got.ExcludedUsers, result.Expected.ExcludedUsers)
+		comparison.CheckStringArraysEqual(result.Got.Users, result.Expected.Users)
 }
 
 type TestResult struct {
@@ -199,9 +198,6 @@ func buildListUsersTestResults(
 			failedListUsersCount++
 
 			got := NoValueString
-			if listUsersResult.Got.Users != nil || listUsersResult.Got.ExcludedUsers != nil {
-				got = fmt.Sprintf("%+v", listUsersResult.Got)
-			}
 
 			userFilter := listUsersResult.Request.UserFilters[0]
 


### PR DESCRIPTION
## Description
Removes `excluded_users` from ListUsers response as it was removed from OpenFGA with https://github.com/openfga/api/pull/171 and https://github.com/openfga/sdk-generator/pull/377.

This feature was originally a well-intentioned way to communicate any negations that may exist on public-typed wildcard (e.g. user:*) as a means of being abundantly clear about what a user:* result entails. However, as we discover more possible situations where excluded users could arise, we realize that we were making a premature decision about the API. We fully intend to re-add excluded_users at some point in the future but may or may not be a flattened list as previously implemented.

This was tested with a locally-generated version of the Go SDK.

**Please note:** 
- This is a draft until the Go SDK is rebuilt
- This is technically a breaking but is acceptable provided that the ListUsers API is still experimental

## References
- Related SDK Generator change: https://github.com/openfga/sdk-generator/pull/377
- Related OpenFGA API change: https://github.com/openfga/api/pull/171

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
