### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
+### [0.5.1](https://github.com/openfga/cli/compare/v0.5.0...v0.5.1) (2024-06-25)
+
+Fixed:
+- Fixed issue where `fga store import` output could no longer be piped to `jq` (#355) - thanks @Siddhant-K-code
+
 ### [0.5.0](https://github.com/openfga/cli/compare/v0.4.1...v0.5.0) (2024-06-18)
 
 Added:
-- `fga store import` now shows a progress bar when writing tuples to show (#348)
+- `fga store import` now shows a progress bar when writing tuples to show (#348) - thanks @Siddhant-K-code
 
 Changed:
 - `excluded_users` has been removed from the `fga query list-users` output and the testing for ListUsers (#347)


### PR DESCRIPTION
## Description

```
Fixed:
- Fixed issue where `fga store import` output could no longer be piped to `jq` (#355) - thanks @Siddhant-K-code
```

Also fixes missing callout on the last release 

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
