### PR TITLE
test: add commander testing infrastucture

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,7 +68,7 @@ jobs:
     - name: Build
       run: make build
 
-    - name: Run unit test
+    - name: Run tests
       run: make test
 
   shellcheck:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
+coverage/
 *.out
 
 # Dependency directories (remove the comment below to include it)

--- a/tests/scripts/run-test-suites.sh
+++ b/tests/scripts/run-test-suites.sh
@@ -1,0 +1,14 @@
+#! /bin/bash -v
+
+docker run -p 8080:8080 -p 8081:8081 -p 3000:3000 -d --name openfga-cli-tests openfga/openfga run
+
+set +e
+
+commander test --dir ./tests
+
+exit_code=$?
+
+docker stop openfga-cli-tests
+docker rm openfga-cli-tests
+
+exit $exit_code

--- a/tests/store-test-cases.yaml
+++ b/tests/store-test-cases.yaml
@@ -1,0 +1,10 @@
+config:
+  inherit-env: true
+
+tests:
+  001 - it successfully uses the store command to create a new store:
+    command: fga store create --name "FGA Demo Store"
+    exit-code: 0
+    stdout:
+      json:
+        store.name: "FGA Demo Store"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

This PR adds support for testing the CLI commands through the use of the [commander tool](https://github.com/commander-cli/commander), and thus having complete E2E tests. Furthermore we are able to also calculate coverage support through the latest Go tool chain improvements.

In order to run the tests, we are using a locally running openfga server that gets spinned up through docker.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
