### PR TITLE
feat: support usage of consistency parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,10 +981,11 @@ fga query **check** <user> <relation> <object> [--condition] [--contextual-tuple
 * `--model-id`: Specifies the model id to target (optional)
 * `--contextual-tuple`: Contextual tuples (optional)
 * `--context`: Condition context (optional)
+* `--consistency`: Consistency preference (optional)
 
 ###### Example
 - `fga query check --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne can_view document:roadmap --contextual-tuple "user:anne can_view folder:product" --contextual-tuple "folder:product parent document:roadmap"`
-- `fga query check --store-id="01H4P8Z95KTXXEP6Z03T75Q984" user:anne can_view document:roadmap --context '{"ip_address":"127.0.0.1"}'`
+- `fga query check --store-id="01H4P8Z95KTXXEP6Z03T75Q984" user:anne can_view document:roadmap --context '{"ip_address":"127.0.0.1"}' --consistency="HIGHER_CONSISTENCY"`
 
 
 ###### Response
@@ -1004,10 +1005,11 @@ fga query **list-objects** <user> <relation> <object_type> [--contextual-tuple "
 * `--model-id`: Specifies the model id to target (optional)
 * `--contextual-tuple`: Contextual tuples (optional) (can be multiple)
 * `--context`: Condition context (optional)
+* `--consistency`: Consistency preference (optional)
 
 ###### Example
 - `fga query list-objects --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne can_view document --contextual-tuple "user:anne can_view folder:product" --contextual-tuple "folder:product parent document:roadmap"`
-- `fga query list-objects --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne can_view document --context '{"ip_address":"127.0.0.1"}`
+- `fga query list-objects --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne can_view document --context '{"ip_address":"127.0.0.1"} --consistency="HIGHER_CONSISTENCY"`
 
 ###### Response
 ```json5
@@ -1029,11 +1031,12 @@ fga query **list-relations** <user> <object> [--relation <relation>]* [--context
 * `--model-id`: Specifies the model id to target (optional)
 * `--contextual-tuple`: Contextual tuples (optional) (can be multiple)
 * `--context`: Condition context (optional)
+* `--consistency`: Consistency preference (optional)
 
 ###### Example
 - `fga query list-relations --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne document:roadmap --relation can_view`
 - `fga query list-relations --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne document:roadmap --relation can_view --contextual-tuple "user:anne can_view folder:product"`
-- `fga query list-relations --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne document:roadmap --relation can_view --context '{"ip_address":"127.0.0.1"}`
+- `fga query list-relations --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne document:roadmap --relation can_view --context '{"ip_address":"127.0.0.1"} --consistency="HIGHER_CONSISTENCY"`
 
 ###### Response
 ```json5
@@ -1052,6 +1055,7 @@ fga query **expand** <relation> <object> --store-id=<store-id> [--model-id=<mode
 ###### Parameters
 * `--store-id`: Specifies the store id
 * `--model-id`: Specifies the model id to target (optional)
+* `--consistency`: Consistency preference (optional)
 
 ###### Example
 `fga query expand --store-id=01H0H015178Y2V4CX10C2KGHF4 can_view document:roadmap`
@@ -1090,11 +1094,12 @@ fga query **list-users** --object <object> --relation <relation> --user-filter <
 * `--model-id`: Specifies the model id to target (optional)
 * `--contextual-tuple`: Contextual tuples (optional) (can be multiple)
 * `--context`: Condition context (optional)
+* `--consistency`: Consistency preference (optional)
 
 ###### Example
 - `fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view --user-filter user`
 - `fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view --user-filter user --contextual-tuple "user:anne can_view folder:product"`
-- `fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view --user-filter group#member --context '{"ip_address":"127.0.0.1"}`
+- `fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view --user-filter group#member --context '{"ip_address":"127.0.0.1"} --consistency="HIGHER_CONSISTENCY"`
 
 ###### Response
 ```json5

--- a/cmd/query/check.go
+++ b/cmd/query/check.go
@@ -63,7 +63,7 @@ func check(
 var checkCmd = &cobra.Command{
 	Use:     "check",
 	Short:   "Check",
-	Example: `fga query check --store-id="01H4P8Z95KTXXEP6Z03T75Q984" user:anne can_view document:roadmap --context '{"ip_address":"127.0.0.1"}'`, //nolint:lll
+	Example: `fga query check --store-id="01H4P8Z95KTXXEP6Z03T75Q984" user:anne can_view document:roadmap --context '{"ip_address":"127.0.0.1"}' --consistency "HIGHER_CONSISTENCY"`, //nolint:lll
 	Long:    "Check if a user has a particular relation with an object.",
 	Args:    cobra.ExactArgs(3), //nolint:mnd
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/query/expand.go
+++ b/cmd/query/expand.go
@@ -58,8 +58,8 @@ var expandCmd = &cobra.Command{
 	Use:     "expand",
 	Short:   "Expand",
 	Long:    "Expands the relationships in userset tree format.",
-	Example: `fga query expand --store-id="01H4P8Z95KTXXEP6Z03T75Q984" can_view document:roadmap`,
-	Args:    cobra.ExactArgs(2), //nolint:mnd
+	Example: `fga query expand --store-id="01H4P8Z95KTXXEP6Z03T75Q984" can_view document:roadmap --consistency "HIGHER_CONSISTENCY"`, //nolint:lll
+	Args:    cobra.ExactArgs(2),                                                                                                      //nolint:mnd,lll
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 

--- a/cmd/query/expand_test.go
+++ b/cmd/query/expand_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"go.uber.org/mock/gomock"
 
@@ -28,17 +29,21 @@ func TestExpandWithError(t *testing.T) {
 
 	mockExecute.EXPECT().Execute().Return(&expectedResponse, errMockExpand)
 
+	mockRequest := mock_client.NewMockSdkClientExpandRequestInterface(mockCtrl)
+	options := client.ClientExpandOptions{}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+
 	mockBody := mock_client.NewMockSdkClientExpandRequestInterface(mockCtrl)
 
 	body := client.ClientExpandRequest{
 		Relation: "writer",
 		Object:   "doc:doc1",
 	}
-	mockBody.EXPECT().Body(body).Return(mockExecute)
+	mockBody.EXPECT().Body(body).Return(mockRequest)
 
 	mockFgaClient.EXPECT().Expand(context.Background()).Return(mockBody)
 
-	_, err := expand(mockFgaClient, "writer", "doc:doc1")
+	_, err := expand(mockFgaClient, "writer", "doc:doc1", openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr())
 	if err == nil {
 		t.Error("Expect error but there is none")
 	}
@@ -62,17 +67,65 @@ func TestExpandWithNoError(t *testing.T) {
 
 	mockExecute.EXPECT().Execute().Return(&expectedResponse, nil)
 
+	mockRequest := mock_client.NewMockSdkClientExpandRequestInterface(mockCtrl)
+	options := client.ClientExpandOptions{}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+
 	mockBody := mock_client.NewMockSdkClientExpandRequestInterface(mockCtrl)
 
 	body := client.ClientExpandRequest{
 		Relation: "writer",
 		Object:   "doc:doc1",
 	}
-	mockBody.EXPECT().Body(body).Return(mockExecute)
+	mockBody.EXPECT().Body(body).Return(mockRequest)
 
 	mockFgaClient.EXPECT().Expand(context.Background()).Return(mockBody)
 
-	output, err := expand(mockFgaClient, "writer", "doc:doc1")
+	output, err := expand(mockFgaClient, "writer", "doc:doc1", openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr())
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !(reflect.DeepEqual(*output, expectedResponse)) {
+		t.Errorf("Expect output response %v actual response %v", expandResponseTxt, *output)
+	}
+}
+
+func TestExpandWithConsistency(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mock_client.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mock_client.NewMockSdkClientExpandRequestInterface(mockCtrl)
+
+	expandResponseTxt := `{"tree":{"root":{"name":"document:roadmap#viewer","union":{"nodes":[{"name": "document:roadmap#viewer","leaf":{"users":{"users":["user:81684243-9356-4421-8fbf-a4f8d36aa31b"]}}}]}}}}` //nolint:all
+
+	expectedResponse := client.ClientExpandResponse{}
+	if err := json.Unmarshal([]byte(expandResponseTxt), &expectedResponse); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	mockExecute.EXPECT().Execute().Return(&expectedResponse, nil)
+
+	mockRequest := mock_client.NewMockSdkClientExpandRequestInterface(mockCtrl)
+	options := client.ClientExpandOptions{
+		Consistency: openfga.CONSISTENCYPREFERENCE_HIGHER_CONSISTENCY.Ptr(),
+	}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+
+	mockBody := mock_client.NewMockSdkClientExpandRequestInterface(mockCtrl)
+
+	body := client.ClientExpandRequest{
+		Relation: "writer",
+		Object:   "doc:doc1",
+	}
+	mockBody.EXPECT().Body(body).Return(mockRequest)
+
+	mockFgaClient.EXPECT().Expand(context.Background()).Return(mockBody)
+
+	output, err := expand(mockFgaClient, "writer", "doc:doc1", openfga.CONSISTENCYPREFERENCE_HIGHER_CONSISTENCY.Ptr())
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/query/list-objects.go
+++ b/cmd/query/list-objects.go
@@ -64,8 +64,8 @@ var listObjectsCmd = &cobra.Command{
 	Use:     "list-objects",
 	Short:   "List Objects",
 	Long:    "List the objects of a certain type that a user has a particular relation to.",
-	Example: `fga query list-objects --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne can_view document --contextual-tuple "user:anne can_view folder:product" --contextual-tuple "folder:product parent document:roadmap"`, //nolint:lll
-	Args:    cobra.ExactArgs(3),                                                                                                                                                                                            //nolint:mnd,lll
+	Example: `fga query list-objects --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne can_view document --contextual-tuple "user:anne can_view folder:product" --contextual-tuple "folder:product parent document:roadmap" --consistency "HIGHER_CONSISTENCY"`, //nolint:lll
+	Args:    cobra.ExactArgs(3),                                                                                                                                                                                                                               //nolint:mnd,lll
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 

--- a/cmd/query/list-objects_test.go
+++ b/cmd/query/list-objects_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"go.uber.org/mock/gomock"
 
@@ -46,7 +47,15 @@ func TestListObjectsWithError(t *testing.T) {
 
 	mockFgaClient.EXPECT().ListObjects(context.Background()).Return(mockBody)
 
-	_, err := listObjects(mockFgaClient, "user:foo", "writer", "doc", contextualTuples, queryContext)
+	_, err := listObjects(
+		mockFgaClient,
+		"user:foo",
+		"writer",
+		"doc",
+		contextualTuples,
+		queryContext,
+		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
+	)
 	if err == nil {
 		t.Error("Expect error but there is none")
 	}
@@ -86,7 +95,69 @@ func TestListObjectsWithNoError(t *testing.T) {
 
 	mockFgaClient.EXPECT().ListObjects(context.Background()).Return(mockBody)
 
-	output, err := listObjects(mockFgaClient, "user:foo", "writer", "doc", contextualTuples, nil)
+	output, err := listObjects(
+		mockFgaClient,
+		"user:foo",
+		"writer",
+		"doc",
+		contextualTuples,
+		nil,
+		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
+	)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if output != &expectedResponse {
+		t.Errorf("Expect %v but actual %v", expectedResponse, *output)
+	}
+}
+
+func TestListObjectsWithConsistency(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFgaClient := mock_client.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mock_client.NewMockSdkClientListObjectsRequestInterface(mockCtrl)
+
+	expectedResponse := client.ClientListObjectsResponse{
+		Objects: []string{"doc:doc1", "doc:doc2"},
+	}
+
+	mockExecute.EXPECT().Execute().Return(&expectedResponse, nil)
+
+	mockRequest := mock_client.NewMockSdkClientListObjectsRequestInterface(mockCtrl)
+	options := client.ClientListObjectsOptions{
+		Consistency: openfga.CONSISTENCYPREFERENCE_HIGHER_CONSISTENCY.Ptr(),
+	}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+
+	mockBody := mock_client.NewMockSdkClientListObjectsRequestInterface(mockCtrl)
+
+	contextualTuples := []client.ClientContextualTupleKey{
+		{User: "user:foo", Relation: "admin", Object: "doc:doc1"},
+	}
+	body := client.ClientListObjectsRequest{
+		User:             "user:foo",
+		Relation:         "writer",
+		Type:             "doc",
+		ContextualTuples: contextualTuples,
+	}
+	mockBody.EXPECT().Body(body).Return(mockRequest)
+
+	mockFgaClient.EXPECT().ListObjects(context.Background()).Return(mockBody)
+
+	output, err := listObjects(
+		mockFgaClient,
+		"user:foo",
+		"writer",
+		"doc",
+		contextualTuples,
+		nil,
+		openfga.CONSISTENCYPREFERENCE_HIGHER_CONSISTENCY.Ptr(),
+	)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/query/list-relations.go
+++ b/cmd/query/list-relations.go
@@ -127,8 +127,8 @@ var listRelationsCmd = &cobra.Command{
 	Use:     "list-relations",
 	Short:   "List Relations",
 	Long:    "List relations that a user has with an object.",
-	Example: `fga query list-relations --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne document:roadmap --relation can_view`, //nolint:lll
-	Args:    cobra.ExactArgs(2),                                                                                              //nolint:mnd,lll
+	Example: `fga query list-relations --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne document:roadmap --relation can_view --consistency "HIGHER_CONSISTENCY"`, //nolint:lll
+	Args:    cobra.ExactArgs(2),                                                                                                                                 //nolint:mnd,lll
 	RunE: func(cmd *cobra.Command, args []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 		fgaClient, err := clientConfig.GetFgaClient()

--- a/cmd/query/list-users.go
+++ b/cmd/query/list-users.go
@@ -94,7 +94,7 @@ var listUsersCmd = &cobra.Command{
 	Use:     "list-users",
 	Short:   "List users",
 	Long:    "List all users that have a certain relation with a particular object",
-	Example: `fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view`,
+	Example: `fga query list-users --store-id=01H0H015178Y2V4CX10C2KGHF4 --object document:roadmap --relation can_view --consistency "HIGHER_CONSISTENCY"`, //nolint:lll
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 		fgaClient, err := clientConfig.GetFgaClient()

--- a/cmd/query/query.go
+++ b/cmd/query/query.go
@@ -42,6 +42,11 @@ func init() {
 	QueryCmd.PersistentFlags().String("model-id", "", "Model ID")
 	QueryCmd.PersistentFlags().StringArray("contextual-tuple", []string{}, `Contextual Tuple, output: "user relation object"`) //nolint:lll
 	QueryCmd.PersistentFlags().String("context", "", "Query context (as a JSON string)")
+	QueryCmd.PersistentFlags().String(
+		"consistency",
+		"",
+		"Consistency preference for the request. Valid options are HIGHER_CONSISTENCY and MINIMIZE_LATENCY.",
+	)
 
 	err := QueryCmd.MarkPersistentFlagRequired("store-id")
 	if err != nil {

--- a/cmd/store/export.go
+++ b/cmd/store/export.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"os"
 
-	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -69,12 +68,7 @@ func buildStoreData(config fga.ClientConfig, fgaClient client.SdkClient, maxTupl
 	// get the tuples
 	maxPages := int(math.Ceil(float64(maxTupleCount) / float64(tuple.DefaultReadPageSize)))
 
-	rawTuples, err := tuple.Read(
-		fgaClient,
-		&client.ClientReadRequest{},
-		maxPages,
-		openfga.CONSISTENCYPREFERENCE_HIGHER_CONSISTENCY.Ptr(),
-	)
+	rawTuples, err := tuple.Read(fgaClient, &client.ClientReadRequest{}, maxPages, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read tuples: %w", err)
 	}

--- a/cmd/store/export.go
+++ b/cmd/store/export.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"os"
 
+	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -68,7 +69,12 @@ func buildStoreData(config fga.ClientConfig, fgaClient client.SdkClient, maxTupl
 	// get the tuples
 	maxPages := int(math.Ceil(float64(maxTupleCount) / float64(tuple.DefaultReadPageSize)))
 
-	rawTuples, err := tuple.Read(fgaClient, &client.ClientReadRequest{}, maxPages, nil)
+	rawTuples, err := tuple.Read(
+		fgaClient,
+		&client.ClientReadRequest{},
+		maxPages,
+		openfga.CONSISTENCYPREFERENCE_HIGHER_CONSISTENCY.Ptr(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read tuples: %w", err)
 	}

--- a/cmd/store/export.go
+++ b/cmd/store/export.go
@@ -68,7 +68,7 @@ func buildStoreData(config fga.ClientConfig, fgaClient client.SdkClient, maxTupl
 	// get the tuples
 	maxPages := int(math.Ceil(float64(maxTupleCount) / float64(tuple.DefaultReadPageSize)))
 
-	rawTuples, err := tuple.Read(fgaClient, &client.ClientReadRequest{}, maxPages)
+	rawTuples, err := tuple.Read(fgaClient, &client.ClientReadRequest{}, maxPages, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read tuples: %w", err)
 	}

--- a/cmd/store/export_test.go
+++ b/cmd/store/export_test.go
@@ -136,7 +136,6 @@ func TestExportSuccess(t *testing.T) {
 	readOptions := client.ClientReadOptions{
 		PageSize:          openfga.PtrInt32(tuple.DefaultReadPageSize),
 		ContinuationToken: openfga.PtrString(""),
-		Consistency:       openfga.CONSISTENCYPREFERENCE_HIGHER_CONSISTENCY.Ptr(),
 	}
 
 	mockReadRequest := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)

--- a/cmd/store/export_test.go
+++ b/cmd/store/export_test.go
@@ -136,6 +136,7 @@ func TestExportSuccess(t *testing.T) {
 	readOptions := client.ClientReadOptions{
 		PageSize:          openfga.PtrInt32(tuple.DefaultReadPageSize),
 		ContinuationToken: openfga.PtrString(""),
+		Consistency:       openfga.CONSISTENCYPREFERENCE_HIGHER_CONSISTENCY.Ptr(),
 	}
 
 	mockReadRequest := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)

--- a/cmd/tuple/read_test.go
+++ b/cmd/tuple/read_test.go
@@ -50,7 +50,14 @@ func TestReadError(t *testing.T) {
 
 	mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody)
 
-	_, err := read(mockFgaClient, "user:user1", "reader", "document:doc1", 5)
+	_, err := read(
+		mockFgaClient,
+		"user:user1",
+		"reader",
+		"document:doc1",
+		5,
+		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
+	)
 	if err == nil {
 		t.Error("Expect error but there is none")
 	}
@@ -91,7 +98,14 @@ func TestReadEmpty(t *testing.T) {
 
 	mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody)
 
-	output, err := read(mockFgaClient, "user:user1", "reader", "document:doc1", 5)
+	output, err := read(
+		mockFgaClient,
+		"user:user1",
+		"reader",
+		"document:doc1",
+		5,
+		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
+	)
 	if err != nil {
 		t.Error(err)
 	}
@@ -166,7 +180,14 @@ func TestReadSinglePage(t *testing.T) {
 
 	mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody)
 
-	output, err := read(mockFgaClient, "user:user1", "reader", "document:doc1", 5)
+	output, err := read(
+		mockFgaClient,
+		"user:user1",
+		"reader",
+		"document:doc1",
+		5,
+		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
+	)
 	if err != nil {
 		t.Error(err)
 	}
@@ -281,7 +302,14 @@ func TestReadMultiPages(t *testing.T) {
 		mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody2),
 	)
 
-	output, err := read(mockFgaClient, "user:user1", "reader", "document:doc1", 5)
+	output, err := read(
+		mockFgaClient,
+		"user:user1",
+		"reader",
+		"document:doc1",
+		5,
+		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
+	)
 	if err != nil {
 		t.Error(err)
 	}
@@ -356,7 +384,14 @@ func TestReadMultiPagesMaxLimit(t *testing.T) {
 
 	mockFgaClient.EXPECT().Read(context.Background()).Return(mockBody)
 
-	output, err := read(mockFgaClient, "user:user1", "reader", "document:doc1", 1)
+	output, err := read(
+		mockFgaClient,
+		"user:user1",
+		"reader",
+		"document:doc1",
+		1,
+		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
+	)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/cmdutils/get-consistency.go
+++ b/internal/cmdutils/get-consistency.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2023 OpenFGA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdutils
+
+import (
+	"fmt"
+	"strings"
+
+	openfga "github.com/openfga/go-sdk"
+	"github.com/spf13/cobra"
+)
+
+func ParseConsistency(consistency string) (*openfga.ConsistencyPreference, error) {
+	if consistency == "" {
+		return openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(), nil
+	}
+
+	val := openfga.ConsistencyPreference(consistency)
+	if val.IsValid() {
+		return &val, nil
+	}
+
+	val = openfga.ConsistencyPreference(strings.ToUpper(consistency))
+	if val.IsValid() {
+		return &val, nil
+	}
+
+	return nil, fmt.Errorf( //nolint:err113
+		"invalid value '%s' for consistency. Valid values are HIGHER_CONSISTENCY and MINIMIZE_LATENCY",
+		consistency,
+	)
+}
+
+func ParseConsistencyFromCmd(cmd *cobra.Command) (*openfga.ConsistencyPreference, error) {
+	consistency, err := cmd.Flags().GetString("consistency")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse consistency due to %w", err)
+	}
+
+	return ParseConsistency(consistency)
+}

--- a/internal/cmdutils/get-consistency_test.go
+++ b/internal/cmdutils/get-consistency_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright © 2023 OpenFGA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdutils_test
+
+import (
+	"testing"
+
+	openfga "github.com/openfga/go-sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openfga/cli/internal/cmdutils"
+)
+
+func TestGetConsistency(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name      string
+		stringVal string
+		expected  *openfga.ConsistencyPreference
+		err       string
+	}{
+		{
+			name:      "handles parsing correct value",
+			stringVal: "HIGHER_CONSISTENCY",
+			expected:  openfga.CONSISTENCYPREFERENCE_HIGHER_CONSISTENCY.Ptr(),
+		},
+		{
+			name:      "handles parsing value from lowercase",
+			stringVal: "higher_consistency",
+			expected:  openfga.CONSISTENCYPREFERENCE_HIGHER_CONSISTENCY.Ptr(),
+		},
+		{
+			name:      "handles no value",
+			stringVal: "",
+			expected:  openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
+		},
+		{
+			name:      "throws for unknown values",
+			stringVal: "invalid",
+			err:       "invalid value 'invalid' for consistency",
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			consistency, err := cmdutils.ParseConsistency(test.stringVal)
+
+			if err == nil {
+				assert.Equal(t, test.expected, consistency)
+			} else {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, test.err)
+			}
+		})
+	}
+}

--- a/internal/tuple/read.go
+++ b/internal/tuple/read.go
@@ -10,7 +10,12 @@ import (
 
 const DefaultReadPageSize int32 = 50
 
-func Read(fgaClient client.SdkClient, body *client.ClientReadRequest, maxPages int) (
+func Read(
+	fgaClient client.SdkClient,
+	body *client.ClientReadRequest,
+	maxPages int,
+	consistency *openfga.ConsistencyPreference,
+) (
 	*openfga.ReadResponse, error,
 ) {
 	tuples := make([]openfga.Tuple, 0)
@@ -18,6 +23,10 @@ func Read(fgaClient client.SdkClient, body *client.ClientReadRequest, maxPages i
 	pageIndex := 0
 	options := client.ClientReadOptions{
 		PageSize: openfga.PtrInt32(DefaultReadPageSize),
+	}
+
+	if consistency != nil && *consistency != openfga.CONSISTENCYPREFERENCE_UNSPECIFIED {
+		options.Consistency = consistency
 	}
 
 	for {


### PR DESCRIPTION
## Description

Adds support for the `--consistency` parameter to the query commands to allow usage of that feature.

For more details see the [relevant openfga/openfga PR](https://github.com/openfga/openfga/pull/1764).

## References

Closes #379

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
