### PR TITLE
refactor: fix lint warnings

### DIFF
--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -74,7 +74,7 @@ func validate(inputModel authorizationmodel.AuthzModel) validationResult {
 			return output
 		}
 
-		createdAt := time.Unix(int64(modelID.Time()/1_000), 0).UTC() //nolint:mnd
+		createdAt := ulid.Time(modelID.Time()).UTC()
 		output.CreatedAt = &createdAt
 	}
 

--- a/cmd/store/import.go
+++ b/cmd/store/import.go
@@ -113,7 +113,7 @@ func importStore(
 	storeData *storetest.StoreData,
 	format authorizationmodel.ModelFormat,
 	storeID string,
-	maxTuplesPerWrite, maxParallelRequests int,
+	maxTuplesPerWrite, maxParallelRequests int32,
 	fileName string,
 ) (*CreateStoreAndModelResponse, error) {
 	var (
@@ -159,8 +159,8 @@ func importStore(
 		}),
 	)
 
-	for index := 0; index < len(storeData.Tuples); index += maxTuplesPerWrite {
-		end := index + maxTuplesPerWrite
+	for index := 0; index < len(storeData.Tuples); index += int(maxTuplesPerWrite) {
+		end := index + int(maxTuplesPerWrite)
 		if end > len(storeData.Tuples) {
 			end = len(storeData.Tuples)
 		}
@@ -202,12 +202,12 @@ var importCmd = &cobra.Command{
 			return fmt.Errorf("failed to get store-id: %w", err)
 		}
 
-		maxTuplesPerWrite, err := cmd.Flags().GetInt("max-tuples-per-write")
+		maxTuplesPerWrite, err := cmd.Flags().GetInt32("max-tuples-per-write")
 		if err != nil {
 			return fmt.Errorf("failed to parse max tuples per write: %w", err)
 		}
 
-		maxParallelRequests, err := cmd.Flags().GetInt("max-parallel-requests")
+		maxParallelRequests, err := cmd.Flags().GetInt32("max-parallel-requests")
 		if err != nil {
 			return fmt.Errorf("failed to parse parallel requests: %w", err)
 		}

--- a/cmd/tuple/delete.go
+++ b/cmd/tuple/delete.go
@@ -59,12 +59,12 @@ var deleteCmd = &cobra.Command{
 				return fmt.Errorf("failed to parse input tuples due to %w", err)
 			}
 
-			maxTuplesPerWrite, err := cmd.Flags().GetInt("max-tuples-per-write")
+			maxTuplesPerWrite, err := cmd.Flags().GetInt32("max-tuples-per-write")
 			if err != nil {
 				return fmt.Errorf("failed to parse max tuples per write due to %w", err)
 			}
 
-			maxParallelRequests, err := cmd.Flags().GetInt("max-parallel-requests")
+			maxParallelRequests, err := cmd.Flags().GetInt32("max-parallel-requests")
 			if err != nil {
 				return fmt.Errorf("failed to parse parallel requests due to %w", err)
 			}

--- a/cmd/tuple/import.go
+++ b/cmd/tuple/import.go
@@ -55,14 +55,14 @@ type ImportResponse struct {
 func ImportTuples(
 	fgaClient client.SdkClient,
 	body client.ClientWriteRequest,
-	maxTuplesPerWrite int,
-	maxParallelRequests int,
+	maxTuplesPerWrite int32,
+	maxParallelRequests int32,
 ) (*ImportResponse, error) {
 	options := client.ClientWriteOptions{
 		Transaction: &client.TransactionOptions{
 			Disable:             true,
-			MaxPerChunk:         int32(maxTuplesPerWrite),
-			MaxParallelRequests: int32(maxParallelRequests),
+			MaxPerChunk:         maxTuplesPerWrite,
+			MaxParallelRequests: maxParallelRequests,
 		},
 	}
 
@@ -168,12 +168,12 @@ var importCmd = &cobra.Command{
 			return fmt.Errorf("failed to parse file name due to %w", err)
 		}
 
-		maxTuplesPerWrite, err := cmd.Flags().GetInt("max-tuples-per-write")
+		maxTuplesPerWrite, err := cmd.Flags().GetInt32("max-tuples-per-write")
 		if err != nil {
 			return fmt.Errorf("failed to parse max tuples per write due to %w", err)
 		}
 
-		maxParallelRequests, err := cmd.Flags().GetInt("max-parallel-requests")
+		maxParallelRequests, err := cmd.Flags().GetInt32("max-parallel-requests")
 		if err != nil {
 			return fmt.Errorf("failed to parse parallel requests due to %w", err)
 		}

--- a/cmd/tuple/write.go
+++ b/cmd/tuple/write.go
@@ -118,12 +118,12 @@ func writeTuplesFromFile(flags *flag.FlagSet, fgaClient *client.OpenFgaClient) e
 		return errors.New("file name cannot be empty") //nolint:goerr113
 	}
 
-	maxTuplesPerWrite, err := flags.GetInt("max-tuples-per-write")
+	maxTuplesPerWrite, err := flags.GetInt32("max-tuples-per-write")
 	if err != nil {
 		return fmt.Errorf("failed to parse max tuples per write: %w", err)
 	}
 
-	maxParallelRequests, err := flags.GetInt("max-parallel-requests")
+	maxParallelRequests, err := flags.GetInt32("max-parallel-requests")
 	if err != nil {
 		return fmt.Errorf("failed to parse parallel requests: %w", err)
 	}

--- a/internal/authorizationmodel/model.go
+++ b/internal/authorizationmodel/model.go
@@ -39,7 +39,7 @@ func getCreatedAtFromModelID(id string) (*time.Time, error) {
 		return nil, fmt.Errorf("error parsing model id %w", err)
 	}
 
-	createdAt := time.Unix(int64(modelID.Time()/1_000), 0).UTC() //nolint:mnd
+	createdAt := ulid.Time(modelID.Time()).UTC()
 
 	return &createdAt, nil
 }
@@ -130,6 +130,8 @@ func (model *AuthzModel) GetCreatedAt() *time.Time {
 
 	if model.ID != nil {
 		createdAt, _ := getCreatedAtFromModelID(model.GetID())
+
+		model.CreatedAt = createdAt
 
 		return createdAt
 	}
@@ -286,7 +288,7 @@ func (model *AuthzModel) setCreatedAt() {
 	if *model.ID != "" {
 		modelID, err := ulid.Parse(*model.ID)
 		if err == nil {
-			createdAt := time.Unix(int64(modelID.Time()/1_000), 0).UTC() //nolint:mnd
+			createdAt := ulid.Time(modelID.Time()).UTC()
 			model.CreatedAt = &createdAt
 		}
 	}

--- a/internal/authorizationmodel/model_test.go
+++ b/internal/authorizationmodel/model_test.go
@@ -12,7 +12,7 @@ import (
 const (
 	modelID        = "01GVKXGDCV2SMG6TRE9NMBQ2VG"
 	typeName       = "user"
-	modelCreatedAt = "2023-03-16 00:35:51 +0000 UTC"
+	modelCreatedAt = "2023-03-16 00:35:51.835 +0000 UTC"
 )
 
 func TestReadingInvalidModelFromInvalidJSON(t *testing.T) {
@@ -49,7 +49,7 @@ func TestReadingValidModelFromJSON(t *testing.T) {
 	}
 
 	if model.CreatedAt.String() != modelCreatedAt {
-		t.Errorf("Expected %v to equal %v", model.CreatedAt.String(), modelCreatedAt)
+		t.Errorf("Expected %v to equal %v", model.GetCreatedAt().String(), modelCreatedAt)
 	}
 
 	if model.GetTypeDefinitions()[0].GetType() != typeName {
@@ -100,7 +100,7 @@ func TestDisplayAsJsonWithFields(t *testing.T) {
 	}
 
 	if jsonModel1.GetCreatedAt().String() != modelCreatedAt {
-		t.Errorf("Expected %v to equal %v", jsonModel1.CreatedAt.String(), modelCreatedAt)
+		t.Errorf("Expected %v to equal %v", jsonModel1.GetCreatedAt().String(), modelCreatedAt)
 	}
 
 	if jsonModel1.GetTypeDefinitions()[0].GetType() != typeName {
@@ -117,7 +117,7 @@ func TestDisplayAsJsonWithFields(t *testing.T) {
 	}
 
 	if jsonModel1.GetCreatedAt().String() != modelCreatedAt {
-		t.Errorf("Expected %v to equal %v", jsonModel2.CreatedAt.String(), modelCreatedAt)
+		t.Errorf("Expected %v to equal %v", jsonModel2.GetCreatedAt().String(), modelCreatedAt)
 	}
 
 	if jsonModel2.GetTypeDefinitions() != nil {


### PR DESCRIPTION
## Description

New version of golangci-lint, new failures. Rather than silence them I tried to approach solving them properly by making use of `ulid.Time` or correctly typing things.

## References

See failures [here](https://github.com/openfga/cli/actions/runs/10631105558/job/29471326424?pr=381)


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
