### PR TITLE
refactor: change default name for model format to improve help text

### DIFF
--- a/internal/authorizationmodel/format.go
+++ b/internal/authorizationmodel/format.go
@@ -25,7 +25,7 @@ import (
 type ModelFormat string
 
 const (
-	ModelFormatDefault ModelFormat = "default"
+	ModelFormatDefault ModelFormat = "autodetect"
 	ModelFormatJSON    ModelFormat = "json"
 	ModelFormatFGA     ModelFormat = "fga"
 	ModelFormatModular ModelFormat = "modular"


### PR DESCRIPTION
## Description

Changes the default format to `autodetect` to better describe the default behaviour

<details>

<summary>fga model transform help text</summary>

```
Flags:
      --file fga.mod           File Name. The file should have the model in the JSON or DSL format or be an fga.mod format
  -h, --help                   help for transform
      --input-format format    Authorization model input format. Can be "fga", "json", or "modular" (default autodetect)
      --output-format format   Authorization model output format. Can be "fga" or "json"." (default autodetect)	
```

</details>

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
