### PR TITLE
test: add integration tests for store import and tuple write/delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ dist/
 
 # Mock source files
 /mocks
+
+# Test files
+/tests/fixtures/identifiers

--- a/tests/fixtures/basic-model.fga
+++ b/tests/fixtures/basic-model.fga
@@ -1,0 +1,8 @@
+model
+  schema 1.1
+
+type user
+
+type group
+  relations
+    define owner: [user]

--- a/tests/fixtures/basic-store.fga.yaml
+++ b/tests/fixtures/basic-store.fga.yaml
@@ -1,0 +1,10 @@
+name: Basic Store
+model_file: basic-model.fga
+tuple_file: basic-tuples.json
+tests:
+  - name: test-1
+    check:
+      - user: user:anne
+        object: group:foo
+        assertions:
+          owner: true

--- a/tests/fixtures/basic-tuples.json
+++ b/tests/fixtures/basic-tuples.json
@@ -1,0 +1,7 @@
+[
+    {
+        "user": "user:anne",
+        "relation": "owner",
+        "object": "group:foo"
+    }
+]

--- a/tests/import-tests-cases.yaml
+++ b/tests/import-tests-cases.yaml
@@ -1,0 +1,10 @@
+config:
+  inherit-env: true
+
+tests:
+  001 - it successfully imports a store:
+    command: fga store import --file=./tests/fixtures/basic-store.fga.yaml --max-parallel-requests=1 --max-tuples-per-write=1
+    exit-code: 0
+    stdout:
+      json:
+        store.name: "Basic Store"

--- a/tests/scripts/run-test-suites.sh
+++ b/tests/scripts/run-test-suites.sh
@@ -11,4 +11,6 @@ exit_code=$?
 docker stop openfga-cli-tests
 docker rm openfga-cli-tests
 
+rm -rf tests/fixtures/identifiers
+
 exit $exit_code

--- a/tests/scripts/test-data/get-model-id.sh
+++ b/tests/scripts/test-data/get-model-id.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+FILE=./tests/fixtures/identifiers/model-id
+if [ -f "$FILE" ]; then
+    cat $FILE
+    exit 0
+fi
+
+STORE_ID=""
+STORE_FILE=./tests/fixtures/identifiers/store-id
+if [ -f "$STORE_FILE" ]; then
+    STORE_ID=$( cat $STORE_FILE )
+else
+    echo "no store created, must create a store before a model"
+    exit 1
+fi
+
+model=$( fga model write --file=./tests/fixtures/basic-model.fga --store-id="$STORE_ID" )
+
+mkdir -p ./tests/fixtures/identifiers
+echo "$model" | jq -r ".authorization_model_id" > $FILE
+cat $FILE

--- a/tests/scripts/test-data/get-store-id.sh
+++ b/tests/scripts/test-data/get-store-id.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+FILE=./tests/fixtures/identifiers/store-id
+if [ -f "$FILE" ]; then
+    cat $FILE
+    exit 0
+fi
+
+store=$( fga store create --name "integration-test-store" )
+
+mkdir -p ./tests/fixtures/identifiers
+echo "$store" | jq -r ".store.id" > $FILE
+cat $FILE

--- a/tests/tuple-test-cases.yaml
+++ b/tests/tuple-test-cases.yaml
@@ -1,0 +1,16 @@
+config:
+  inherit-env: true
+
+tests:
+  001 - it successfully writes tuples to a store:
+    command: fga tuple write --file=./tests/fixtures/basic-tuples.json --max-tuples-per-write=1 --max-parallel-requests=1 --store-id=$(./tests/scripts/test-data/get-store-id.sh) --model-id=$(./tests/scripts/test-data/get-model-id.sh)
+    exit-code: 0
+    stdout:
+      json:
+        successful.0.user: "user:anne"
+  002 - it successfully deletes tuples from a store:
+    command: fga tuple delete --file=./tests/fixtures/basic-tuples.json --max-tuples-per-write=1 --max-parallel-requests=1 --store-id=$(./tests/scripts/test-data/get-store-id.sh) --model-id=$(./tests/scripts/test-data/get-model-id.sh)
+    exit-code: 0
+    stdout:
+      json:
+        successful.0.user: "user:anne"


### PR DESCRIPTION
## Description

Adds tests that cover the failure cases from #387

This is the first example of how we can potentially create and reuse stores and models between tests based on the learnings from Auth0 CLI testing. Although we might not need that, being able to reuse between tests might shave off a small amount of time.

These will fail until #389 is merged

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
