### PR TITLE
fix(test): set got users from the response if not nil

### DIFF
--- a/internal/storetest/testresult.go
+++ b/internal/storetest/testresult.go
@@ -199,6 +199,10 @@ func buildListUsersTestResults(
 
 			got := NoValueString
 
+			if listUsersResult.Got.Users != nil {
+				got = fmt.Sprintf("%+v", listUsersResult.Got)
+			}
+
 			userFilter := listUsersResult.Request.UserFilters[0]
 
 			listUsersResultsOutput += fmt.Sprintf(


### PR DESCRIPTION
## Description

Looks like this accidentally go dropped during the refactor to remove excluded users

## References

Fixes #388

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
