### PR TITLE
release: v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### [0.6.1](https://github.com/openfga/cli/compare/v0.6.0...v0.6.1) (2024-09-09)
+
+Fixed:
+- Fixed issue where `fga store import`, `fga tuple write` and `fga tuple delete` could not be ran due to an issue with the `--max-tuples-per-write` and `--max-parallel-requests` options (#389)
+- Fixed an issue where List Users failed test output did not include the returned response (#391)
+
 ### [0.6.0](https://github.com/openfga/cli/compare/v0.5.3...v0.6.0) (2024-09-08)
 
 Added:


### PR DESCRIPTION
## Description

```
### [0.6.1](https://github.com/openfga/cli/compare/v0.6.0...v0.6.1) (2024-09-09)

Fixed:
- Fixed issue where `fga store import`, `fga tuple write` and `fga tuple delete` could not be ran due to an issue with the `--max-tuples-per-write` and `--max-parallel-requests` options (#389)
- Fixed an issue where List Users failed test output did not include the returned response (#391)
```

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
