### PR TITLE
Add `--no-pretty` global flag for parsable CLI output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,7 @@ func init() {
 	rootCmd.PersistentFlags().String("client-id", "", "Client ID. Sent to the Token Issuer during the Client Credentials flow")                            //nolint:lll
 	rootCmd.PersistentFlags().String("client-secret", "", "Client Secret. Sent to the Token Issuer during the Client Credentials flow")                    //nolint:lll
 	rootCmd.PersistentFlags().StringArray("api-scopes", []string{}, "API Scopes (repeat option for multiple values). Used in the Client Credentials flow") //nolint:lll
+	rootCmd.PersistentFlags().Bool("no-pretty", false, "Disable pretty output features (useful for scripting)")                                            //nolint:lll
 
 	rootCmd.MarkFlagsRequiredTogether(
 		"api-token-issuer",

--- a/internal/output/marshal.go
+++ b/internal/output/marshal.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/gocarina/gocsv"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 
 	"github.com/mattn/go-isatty"
@@ -184,6 +185,10 @@ func outputNonTerminal(data any) error {
 
 // Display will decorate the output if possible.  Otherwise, will print out the standard JSON.
 func Display(data any) error {
+	if viper.GetBool("no-pretty") {
+		return outputParsable(data)
+	}
+
 	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 		if os.Getenv("NO_COLOR") != "" {
 			return displayNoColorTerminal(data)
@@ -193,4 +198,13 @@ func Display(data any) error {
 	}
 
 	return outputNonTerminal(data)
+}
+
+func outputParsable(data any) error {
+	result, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("unable to marshal json with error %w", err)
+	}
+	fmt.Println(string(result))
+	return nil
 }


### PR DESCRIPTION
This pull request adds a new global flag, `--no-pretty`, to the CLI. When this flag is set, it disables the pretty output features, making the output more suitable for scripting purposes. This is useful for cases where the CLI output needs to be parsed programmatically.


Fixes #361