### PR TITLE
simplify err messages in check function

### DIFF
--- a/cmd/model/list.go
+++ b/cmd/model/list.go
@@ -95,7 +95,7 @@ var listCmd = &cobra.Command{
 
 		models := authorizationmodel.AuthzModelList{}
 		authzModels := response.AuthorizationModels
-		for index := range len(authzModels) {
+		for index := range authzModels {
 			authModel := authorizationmodel.AuthzModel{}
 			authModel.Set(authzModels[index])
 			models.AuthorizationModels = append(models.AuthorizationModels, authModel.DisplayAsJSON(fields))

--- a/cmd/query/check.go
+++ b/cmd/query/check.go
@@ -53,7 +53,7 @@ func check(
 
 	response, err := fgaClient.Check(context.Background()).Body(*body).Options(*options).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("due to %w", err)
+		return nil, err //nolint:wrapcheck
 	}
 
 	return response, nil
@@ -90,7 +90,7 @@ var checkCmd = &cobra.Command{
 
 		response, err := check(fgaClient, args[0], args[1], args[2], contextualTuples, queryContext, consistency)
 		if err != nil {
-			return fmt.Errorf("check failed %w", err)
+			return fmt.Errorf("check failed: %w", err)
 		}
 
 		return output.Display(*response)

--- a/cmd/query/check.go
+++ b/cmd/query/check.go
@@ -53,7 +53,7 @@ func check(
 
 	response, err := fgaClient.Check(context.Background()).Body(*body).Options(*options).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("failed to check due to %w", err)
+		return nil, fmt.Errorf("due to %w", err)
 	}
 
 	return response, nil
@@ -90,7 +90,7 @@ var checkCmd = &cobra.Command{
 
 		response, err := check(fgaClient, args[0], args[1], args[2], contextualTuples, queryContext, consistency)
 		if err != nil {
-			return fmt.Errorf("failed to check due to %w", err)
+			return fmt.Errorf("check failed %w", err)
 		}
 
 		return output.Display(*response)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This pull request updates the error messages in the check function to provide more informative and concise error messages. The "failed to check" error message has been changed to "check failed" to better reflect the actual error.

Updated error message would look like:

> Error: check failed: <error_message>

Actual Example: 

> Error: check failed: Post "http://localhost:8080/stores/01H4P8Z95KTXXEP6Z03T75Q984/check": dial tcp [::1]:8080: connect: connection refused

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

fixes #404

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
