### PR TITLE
chore: hide server-url flag from help output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,7 @@ func init() {
 	// it is still kept here for backward compatibility
 	rootCmd.PersistentFlags().String("server-url", "http://localhost:8080", "OpenFGA API URI e.g. https://api.fga.example:8080") //nolint:lll
 	rootCmd.PersistentFlags().String("api-url", "http://localhost:8080", "OpenFGA API URI e.g. https://api.fga.example:8080")    //nolint:lll
+	_ = rootCmd.PersistentFlags().MarkHidden("server-url")
 
 	rootCmd.PersistentFlags().String("api-token", "", "API Token. Will be sent in as a Bearer in the Authorization header")
 	rootCmd.PersistentFlags().String("api-token-issuer", "", "API Token Issuer. API responsible for issuing the API Token. Used in the Client Credentials flow") //nolint:lll


### PR DESCRIPTION
## Description

Given that it is deprecated, hide the `--server-url` flag from the help output. I did not change to use `MarkDeprecated` because we're already logging ourselves [here](https://github.com/openfga/cli/blob/main/internal/cmdutils/get-client-config.go#L32-L36)

## References


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
