### PR TITLE
feat: support importing assertions as part of a store

### DIFF
--- a/cmd/store/create.go
+++ b/cmd/store/create.go
@@ -67,7 +67,7 @@ func CreateStoreWithModel(
 
 	err = fgaClient.SetStoreId(response.Store.Id)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to set store ID: %w", err)
 	}
 
 	if inputModel != "" {

--- a/cmd/store/create.go
+++ b/cmd/store/create.go
@@ -65,6 +65,11 @@ func CreateStoreWithModel(
 
 	response.Store = *createStoreResponse
 
+	err = fgaClient.SetStoreId(response.Store.Id)
+	if err != nil {
+		return nil, err
+	}
+
 	if inputModel != "" {
 		authModel := authorizationmodel.AuthzModel{}
 

--- a/cmd/store/import.go
+++ b/cmd/store/import.go
@@ -49,6 +49,7 @@ const (
 // createStore creates a new store with the given client configuration and store data.
 func createStore(
 	clientConfig *fga.ClientConfig,
+	fgaClient client.SdkClient,
 	storeData *storetest.StoreData,
 	format authorizationmodel.ModelFormat,
 	fileName string,
@@ -58,7 +59,7 @@ func createStore(
 		storeDataName = strings.TrimSuffix(path.Base(fileName), ".fga.yaml")
 	}
 
-	createStoreAndModelResponse, err := CreateStoreWithModel(*clientConfig, storeDataName, storeData.Model, format)
+	createStoreAndModelResponse, err := CreateStoreWithModel(fgaClient, storeDataName, storeData.Model, format)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +144,7 @@ func createOrUpdateStore(
 	fileName string,
 ) (*CreateStoreAndModelResponse, error) {
 	if storeID == "" {
-		return createStore(clientConfig, storeData, format, fileName)
+		return createStore(clientConfig, fgaClient, storeData, format, fileName)
 	}
 
 	return updateStore(clientConfig, fgaClient, storeData, format, storeID)

--- a/cmd/store/import.go
+++ b/cmd/store/import.go
@@ -192,8 +192,8 @@ func importTuples(
 func importAssertions(
 	fgaClient client.SdkClient,
 	modelTests []storetest.ModelTest,
-	storeId string,
-	modelId string,
+	storeID string,
+	modelID string,
 ) error {
 	var assertions []client.ClientAssertion
 
@@ -206,14 +206,16 @@ func importAssertions(
 
 	if len(assertions) > 0 {
 		writeOptions := client.ClientWriteAssertionsOptions{
-			AuthorizationModelId: &modelId,
-			StoreId:              &storeId,
+			AuthorizationModelId: &modelID,
+			StoreId:              &storeID,
 		}
 
-		if _, err := fgaClient.WriteAssertions(context.Background()).Body(assertions).Options(writeOptions).Execute(); err != nil {
+		_, err := fgaClient.WriteAssertions(context.Background()).Body(assertions).Options(writeOptions).Execute()
+		if err != nil {
 			return fmt.Errorf("failed to import assertions: %w", err)
 		}
 	}
+
 	return nil
 }
 

--- a/cmd/store/import_test.go
+++ b/cmd/store/import_test.go
@@ -132,8 +132,6 @@ func TestImportStore(t *testing.T) {
 func TestUpdateStore(t *testing.T) {
 	t.Parallel()
 
-	clientConfig := fga.ClientConfig{}
-
 	expectedAssertions := []client.ClientAssertion{{
 		User:        "user:anne",
 		Relation:    "reader",
@@ -201,6 +199,8 @@ func TestUpdateStore(t *testing.T) {
 	for _, test := range importStoreTests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+
+			clientConfig := fga.ClientConfig{}
 
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()

--- a/cmd/store/import_test.go
+++ b/cmd/store/import_test.go
@@ -8,76 +8,225 @@ import (
 	"github.com/openfga/go-sdk/client"
 	"go.uber.org/mock/gomock"
 	"testing"
+	"time"
 )
 
 func TestImportStore(t *testing.T) {
 	t.Parallel()
 
-	t.Run("imports assertions into store", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		defer mockCtrl.Finish()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
 
-		mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
-		clientConfig := fga.ClientConfig{}
+	mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+	clientConfig := fga.ClientConfig{}
 
-		mockWriteAssertions := mockclient.NewMockSdkClientWriteAssertionsRequestInterface(mockCtrl)
-		mockCreateStore := mockclient.NewMockSdkClientCreateStoreRequestInterface(mockCtrl)
-		mockWriteModel := mockclient.NewMockSdkClientWriteAuthorizationModelRequestInterface(mockCtrl)
+	expectedAssertions := []client.ClientAssertion{{
+		User:        "user:anne",
+		Relation:    "reader",
+		Object:      "document:doc1",
+		Expectation: true,
+	}}
 
-		expectedAssertions := []client.ClientAssertion{{
-			User:        "user:anne",
-			Relation:    "reader",
-			Object:      "document:doc1",
-			Expectation: true,
-		}}
+	modelID := "model-1"
+	storeID := "store-1"
+	sampleTime := time.Now()
+	expectedOptions := client.ClientWriteAssertionsOptions{
+		AuthorizationModelId: &modelID,
+		StoreId:              &storeID,
+	}
 
-		modelID := "model-1"
-		storeID := "store-1"
-		expectedOptions := client.ClientWriteAssertionsOptions{
-			AuthorizationModelId: &modelID,
-			StoreId:              &storeID,
-		}
-
-		mockFgaClient.EXPECT().CreateStore(context.Background()).Return(mockCreateStore)
-		mockCreateStore.EXPECT().Body(gomock.Any()).Return(mockCreateStore)
-		mockCreateStore.EXPECT().Execute().Return(&client.ClientCreateStoreResponse{Id: "store-1"}, nil)
-
-		mockFgaClient.EXPECT().SetStoreId("store-1")
-
-		mockFgaClient.EXPECT().WriteAuthorizationModel(context.Background()).Return(mockWriteModel)
-		mockWriteModel.EXPECT().Body(gomock.Any()).Return(mockWriteModel)
-		mockWriteModel.EXPECT().Execute().Return(&client.ClientWriteAuthorizationModelResponse{AuthorizationModelId: "model-1"}, nil)
-
-		mockFgaClient.EXPECT().WriteAssertions(context.Background()).Return(mockWriteAssertions)
-		mockWriteAssertions.EXPECT().Body(expectedAssertions).Return(mockWriteAssertions)
-		mockWriteAssertions.EXPECT().Options(expectedOptions).Return(mockWriteAssertions)
-		mockWriteAssertions.EXPECT().Execute().Return(nil, nil)
-
-		testStore := &storetest.StoreData{
-			Name: "test-store",
-			Model: `type user
+	defaultStore := storetest.StoreData{
+		Name: "test-store",
+		Model: `type user
 					type document
 						relations
 							define reader: [user]`,
-			Tests: []storetest.ModelTest{
-				{
-					Name: "Test",
-					Check: []storetest.ModelTestCheck{
-						{
-							User:   "user:anne",
-							Object: "document:doc1",
-							Assertions: map[string]bool{
-								"reader": true,
+		Tests: []storetest.ModelTest{
+			{
+				Name: "Test",
+				Check: []storetest.ModelTestCheck{
+					{
+						User:   "user:anne",
+						Object: "document:doc1",
+						Assertions: map[string]bool{
+							"reader": true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	importStoreTests := []struct {
+		name                string
+		mockWriteAssertions bool
+		mockGetStore        bool
+		mockCreateStore     bool
+		mockWriteModel      bool
+		testStore           storetest.StoreData
+		storeId             string
+	}{
+		{
+			name:                "import store with assertions",
+			mockWriteAssertions: true,
+			mockGetStore:        false,
+			mockWriteModel:      true,
+			mockCreateStore:     true,
+			testStore:           defaultStore,
+			storeId:             "",
+		},
+		{
+			name:                "create new store without assertions",
+			mockWriteAssertions: false,
+			mockCreateStore:     true,
+			mockGetStore:        false,
+			mockWriteModel:      false,
+			testStore: storetest.StoreData{
+				Name: "test-store",
+			},
+			storeId: "",
+		},
+		{
+			name:                "create new store without check assertions",
+			mockCreateStore:     true,
+			mockWriteModel:      true,
+			mockWriteAssertions: false,
+			testStore: storetest.StoreData{
+				Name: "test-store",
+				Model: `type user
+					type document
+						relations
+							define reader: [user]`,
+				Tests: []storetest.ModelTest{
+					{
+						Name: "Test",
+						ListObjects: []storetest.ModelTestListObjects{
+							{
+								User: "user:anne",
+								Type: "organization",
+								Assertions: map[string][]string{
+									"member": {"organization:acme"},
+								},
 							},
 						},
 					},
 				},
 			},
-		}
-		_, err := importStore(&clientConfig, mockFgaClient, testStore, "", "", 1, 1, "")
+			storeId: "",
+		},
+		{
+			name:                "do not write assertions if imported store does not have a model",
+			mockCreateStore:     true,
+			mockWriteAssertions: false,
+			testStore: storetest.StoreData{
+				Name: "test-store",
+				Tests: []storetest.ModelTest{
+					{
+						Name: "Test",
+						ListObjects: []storetest.ModelTestListObjects{
+							{
+								User: "user:anne",
+								Type: "organization",
+								Assertions: map[string][]string{
+									"member": {"organization:acme"},
+								},
+							},
+						},
+					},
+				},
+			},
+			storeId: "",
+		},
+		{
+			name:                "update store with assertions",
+			mockWriteAssertions: true,
+			mockGetStore:        true,
+			mockWriteModel:      true,
+			testStore: storetest.StoreData{
+				Name: "test-store",
+				Model: `type user
+					type document
+						relations
+							define reader: [user]`,
+				Tests: []storetest.ModelTest{
+					{
+						Name: "Test",
+						Check: []storetest.ModelTestCheck{
+							{
+								User:   "user:anne",
+								Object: "document:doc1",
+								Assertions: map[string]bool{
+									"reader": true,
+								},
+							},
+						},
+					},
+				},
+			},
+			storeId: storeID,
+		},
+		{
+			name:                "update store without assertions",
+			mockWriteAssertions: false,
+			mockGetStore:        true,
+			mockWriteModel:      true,
+			testStore: storetest.StoreData{
+				Name: "test-store",
+				Model: `type user
+					type document
+						relations
+							define reader: [user]`,
+			},
+			storeId: storeID,
+		},
+	}
 
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-	})
+	for _, test := range importStoreTests {
+
+		t.Run(test.name, func(t *testing.T) {
+
+			if test.mockWriteAssertions {
+				mockWriteAssertions := mockclient.NewMockSdkClientWriteAssertionsRequestInterface(mockCtrl)
+				mockFgaClient.EXPECT().WriteAssertions(context.Background()).Return(mockWriteAssertions)
+				mockWriteAssertions.EXPECT().Body(expectedAssertions).Return(mockWriteAssertions)
+				mockWriteAssertions.EXPECT().Options(expectedOptions).Return(mockWriteAssertions)
+				mockWriteAssertions.EXPECT().Execute().Return(nil, nil)
+			} else {
+				mockFgaClient.EXPECT().WriteAssertions(context.Background()).Times(0)
+			}
+
+			if test.mockWriteModel {
+				mockWriteModel := mockclient.NewMockSdkClientWriteAuthorizationModelRequestInterface(mockCtrl)
+				mockFgaClient.EXPECT().WriteAuthorizationModel(context.Background()).Return(mockWriteModel)
+				mockWriteModel.EXPECT().Body(gomock.Any()).Return(mockWriteModel)
+				mockWriteModel.EXPECT().Execute().Return(&client.ClientWriteAuthorizationModelResponse{AuthorizationModelId: modelID}, nil)
+			}
+
+			if test.mockCreateStore {
+				mockCreateStore := mockclient.NewMockSdkClientCreateStoreRequestInterface(mockCtrl)
+				mockFgaClient.EXPECT().CreateStore(context.Background()).Return(mockCreateStore)
+				mockCreateStore.EXPECT().Body(gomock.Any()).Return(mockCreateStore)
+				mockCreateStore.EXPECT().Execute().Return(&client.ClientCreateStoreResponse{Id: storeID}, nil)
+				mockFgaClient.EXPECT().SetStoreId(storeID)
+			}
+
+			if test.mockGetStore {
+				mockGetStore := mockclient.NewMockSdkClientGetStoreRequestInterface(mockCtrl)
+				mockFgaClient.EXPECT().GetStore(context.Background()).Return(mockGetStore)
+				mockGetStore.EXPECT().Execute().Return(&client.ClientGetStoreResponse{Id: storeID, Name: "test-store", CreatedAt: sampleTime, UpdatedAt: sampleTime}, nil)
+			}
+
+			var err error
+			if storeID != "" {
+				_, err = importStore(&clientConfig, mockFgaClient, &test.testStore, "", test.storeId, 1, 1, "")
+			} else {
+				_, err = importStore(&clientConfig, mockFgaClient, &test.testStore, "", "", 1, 1, "")
+			}
+
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+
+		})
+	}
 }

--- a/cmd/store/import_test.go
+++ b/cmd/store/import_test.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"context"
+	"github.com/openfga/cli/internal/fga"
+	mockclient "github.com/openfga/cli/internal/mocks"
+	"github.com/openfga/cli/internal/storetest"
+	"github.com/openfga/go-sdk/client"
+	"go.uber.org/mock/gomock"
+	"testing"
+)
+
+func TestImportStore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("imports assertions into store", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+		clientConfig := fga.ClientConfig{}
+
+		mockWriteAssertions := mockclient.NewMockSdkClientWriteAssertionsRequestInterface(mockCtrl)
+		mockCreateStore := mockclient.NewMockSdkClientCreateStoreRequestInterface(mockCtrl)
+		mockWriteModel := mockclient.NewMockSdkClientWriteAuthorizationModelRequestInterface(mockCtrl)
+
+		expectedAssertions := []client.ClientAssertion{{
+			User:        "user:anne",
+			Relation:    "reader",
+			Object:      "document:doc1",
+			Expectation: true,
+		}}
+
+		modelID := "model-1"
+		storeID := "store-1"
+		expectedOptions := client.ClientWriteAssertionsOptions{
+			AuthorizationModelId: &modelID,
+			StoreId:              &storeID,
+		}
+
+		mockFgaClient.EXPECT().CreateStore(context.Background()).Return(mockCreateStore)
+		mockCreateStore.EXPECT().Body(gomock.Any()).Return(mockCreateStore)
+		mockCreateStore.EXPECT().Execute().Return(&client.ClientCreateStoreResponse{Id: "store-1"}, nil)
+
+		mockFgaClient.EXPECT().SetStoreId("store-1")
+
+		mockFgaClient.EXPECT().WriteAuthorizationModel(context.Background()).Return(mockWriteModel)
+		mockWriteModel.EXPECT().Body(gomock.Any()).Return(mockWriteModel)
+		mockWriteModel.EXPECT().Execute().Return(&client.ClientWriteAuthorizationModelResponse{AuthorizationModelId: "model-1"}, nil)
+
+		mockFgaClient.EXPECT().WriteAssertions(context.Background()).Return(mockWriteAssertions)
+		mockWriteAssertions.EXPECT().Body(expectedAssertions).Return(mockWriteAssertions)
+		mockWriteAssertions.EXPECT().Options(expectedOptions).Return(mockWriteAssertions)
+		mockWriteAssertions.EXPECT().Execute().Return(nil, nil)
+
+		testStore := &storetest.StoreData{
+			Name: "test-store",
+			Model: `type user
+					type document
+						relations
+							define reader: [user]`,
+			Tests: []storetest.ModelTest{
+				{
+					Name: "Test",
+					Check: []storetest.ModelTestCheck{
+						{
+							User:   "user:anne",
+							Object: "document:doc1",
+							Assertions: map[string]bool{
+								"reader": true,
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := importStore(&clientConfig, mockFgaClient, testStore, "", "", 1, 1, "")
+
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}

--- a/cmd/store/import_test.go
+++ b/cmd/store/import_test.go
@@ -2,22 +2,136 @@ package store
 
 import (
 	"context"
+	"testing"
+	"time"
+
+	"github.com/openfga/go-sdk/client"
+	"go.uber.org/mock/gomock"
+
 	"github.com/openfga/cli/internal/fga"
 	mockclient "github.com/openfga/cli/internal/mocks"
 	"github.com/openfga/cli/internal/storetest"
-	"github.com/openfga/go-sdk/client"
-	"go.uber.org/mock/gomock"
-	"testing"
-	"time"
 )
 
 func TestImportStore(t *testing.T) {
 	t.Parallel()
 
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
+	expectedAssertions := []client.ClientAssertion{{
+		User:        "user:anne",
+		Relation:    "reader",
+		Object:      "document:doc1",
+		Expectation: true,
+	}}
+	modelID, storeID := "model-1", "store-1"
+	expectedOptions := client.ClientWriteAssertionsOptions{AuthorizationModelId: &modelID, StoreId: &storeID}
 
-	mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+	importStoreTests := []struct {
+		name                string
+		mockWriteAssertions bool
+		mockCreateStore     bool
+		mockWriteModel      bool
+		testStore           storetest.StoreData
+	}{
+		{
+			name:                "import store with assertions",
+			mockWriteAssertions: true,
+			mockWriteModel:      true,
+			mockCreateStore:     true,
+			testStore: storetest.StoreData{
+				Model: `type user
+					type document
+						relations
+							define reader: [user]`,
+				Tests: []storetest.ModelTest{
+					{
+						Name: "Test",
+						Check: []storetest.ModelTestCheck{
+							{
+								User:       "user:anne",
+								Object:     "document:doc1",
+								Assertions: map[string]bool{"reader": true},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                "create new store without assertions",
+			mockWriteAssertions: false,
+			mockCreateStore:     true,
+			mockWriteModel:      false,
+			testStore:           storetest.StoreData{Name: "test-store"},
+		},
+		{
+			name:                "create new store without check assertions",
+			mockCreateStore:     true,
+			mockWriteModel:      true,
+			mockWriteAssertions: false,
+			testStore: storetest.StoreData{
+				Model: `type user
+					type document
+						relations
+							define reader: [user]`,
+				Tests: []storetest.ModelTest{
+					{
+						Name: "Test",
+						ListObjects: []storetest.ModelTestListObjects{
+							{
+								User:       "user:anne",
+								Type:       "organization",
+								Assertions: map[string][]string{"member": {"organization:acme"}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                "do not write assertions if imported store does not have a model",
+			mockCreateStore:     true,
+			mockWriteAssertions: false,
+			testStore: storetest.StoreData{
+				Tests: []storetest.ModelTest{
+					{Name: "Test"},
+				},
+			},
+		},
+	}
+
+	for _, test := range importStoreTests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+
+			defer mockCtrl.Finish()
+
+			if test.mockWriteAssertions {
+				setupWriteAssertionsMock(mockCtrl, mockFgaClient, expectedAssertions, expectedOptions)
+			} else {
+				mockFgaClient.EXPECT().WriteAssertions(context.Background()).Times(0)
+			}
+
+			if test.mockWriteModel {
+				setupWriteModelMock(mockCtrl, mockFgaClient, modelID)
+			}
+
+			if test.mockCreateStore {
+				setupCreateStoreMock(mockCtrl, mockFgaClient, storeID)
+			}
+
+			_, err := importStore(&fga.ClientConfig{}, mockFgaClient, &test.testStore, "", "", 1, 1, "")
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestUpdateStore(t *testing.T) {
+	t.Parallel()
+
 	clientConfig := fga.ClientConfig{}
 
 	expectedAssertions := []client.ClientAssertion{{
@@ -35,108 +149,13 @@ func TestImportStore(t *testing.T) {
 		StoreId:              &storeID,
 	}
 
-	defaultStore := storetest.StoreData{
-		Name: "test-store",
-		Model: `type user
-					type document
-						relations
-							define reader: [user]`,
-		Tests: []storetest.ModelTest{
-			{
-				Name: "Test",
-				Check: []storetest.ModelTestCheck{
-					{
-						User:   "user:anne",
-						Object: "document:doc1",
-						Assertions: map[string]bool{
-							"reader": true,
-						},
-					},
-				},
-			},
-		},
-	}
-
 	importStoreTests := []struct {
 		name                string
 		mockWriteAssertions bool
 		mockGetStore        bool
-		mockCreateStore     bool
 		mockWriteModel      bool
 		testStore           storetest.StoreData
-		storeId             string
 	}{
-		{
-			name:                "import store with assertions",
-			mockWriteAssertions: true,
-			mockGetStore:        false,
-			mockWriteModel:      true,
-			mockCreateStore:     true,
-			testStore:           defaultStore,
-			storeId:             "",
-		},
-		{
-			name:                "create new store without assertions",
-			mockWriteAssertions: false,
-			mockCreateStore:     true,
-			mockGetStore:        false,
-			mockWriteModel:      false,
-			testStore: storetest.StoreData{
-				Name: "test-store",
-			},
-			storeId: "",
-		},
-		{
-			name:                "create new store without check assertions",
-			mockCreateStore:     true,
-			mockWriteModel:      true,
-			mockWriteAssertions: false,
-			testStore: storetest.StoreData{
-				Name: "test-store",
-				Model: `type user
-					type document
-						relations
-							define reader: [user]`,
-				Tests: []storetest.ModelTest{
-					{
-						Name: "Test",
-						ListObjects: []storetest.ModelTestListObjects{
-							{
-								User: "user:anne",
-								Type: "organization",
-								Assertions: map[string][]string{
-									"member": {"organization:acme"},
-								},
-							},
-						},
-					},
-				},
-			},
-			storeId: "",
-		},
-		{
-			name:                "do not write assertions if imported store does not have a model",
-			mockCreateStore:     true,
-			mockWriteAssertions: false,
-			testStore: storetest.StoreData{
-				Name: "test-store",
-				Tests: []storetest.ModelTest{
-					{
-						Name: "Test",
-						ListObjects: []storetest.ModelTestListObjects{
-							{
-								User: "user:anne",
-								Type: "organization",
-								Assertions: map[string][]string{
-									"member": {"organization:acme"},
-								},
-							},
-						},
-					},
-				},
-			},
-			storeId: "",
-		},
 		{
 			name:                "update store with assertions",
 			mockWriteAssertions: true,
@@ -163,7 +182,6 @@ func TestImportStore(t *testing.T) {
 					},
 				},
 			},
-			storeId: storeID,
 		},
 		{
 			name:                "update store without assertions",
@@ -177,56 +195,83 @@ func TestImportStore(t *testing.T) {
 						relations
 							define reader: [user]`,
 			},
-			storeId: storeID,
 		},
 	}
 
 	for _, test := range importStoreTests {
-
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+
+			defer mockCtrl.Finish()
 
 			if test.mockWriteAssertions {
-				mockWriteAssertions := mockclient.NewMockSdkClientWriteAssertionsRequestInterface(mockCtrl)
-				mockFgaClient.EXPECT().WriteAssertions(context.Background()).Return(mockWriteAssertions)
-				mockWriteAssertions.EXPECT().Body(expectedAssertions).Return(mockWriteAssertions)
-				mockWriteAssertions.EXPECT().Options(expectedOptions).Return(mockWriteAssertions)
-				mockWriteAssertions.EXPECT().Execute().Return(nil, nil)
+				setupWriteAssertionsMock(mockCtrl, mockFgaClient, expectedAssertions, expectedOptions)
 			} else {
 				mockFgaClient.EXPECT().WriteAssertions(context.Background()).Times(0)
 			}
 
 			if test.mockWriteModel {
-				mockWriteModel := mockclient.NewMockSdkClientWriteAuthorizationModelRequestInterface(mockCtrl)
-				mockFgaClient.EXPECT().WriteAuthorizationModel(context.Background()).Return(mockWriteModel)
-				mockWriteModel.EXPECT().Body(gomock.Any()).Return(mockWriteModel)
-				mockWriteModel.EXPECT().Execute().Return(&client.ClientWriteAuthorizationModelResponse{AuthorizationModelId: modelID}, nil)
-			}
-
-			if test.mockCreateStore {
-				mockCreateStore := mockclient.NewMockSdkClientCreateStoreRequestInterface(mockCtrl)
-				mockFgaClient.EXPECT().CreateStore(context.Background()).Return(mockCreateStore)
-				mockCreateStore.EXPECT().Body(gomock.Any()).Return(mockCreateStore)
-				mockCreateStore.EXPECT().Execute().Return(&client.ClientCreateStoreResponse{Id: storeID}, nil)
-				mockFgaClient.EXPECT().SetStoreId(storeID)
+				setupWriteModelMock(mockCtrl, mockFgaClient, modelID)
 			}
 
 			if test.mockGetStore {
-				mockGetStore := mockclient.NewMockSdkClientGetStoreRequestInterface(mockCtrl)
-				mockFgaClient.EXPECT().GetStore(context.Background()).Return(mockGetStore)
-				mockGetStore.EXPECT().Execute().Return(&client.ClientGetStoreResponse{Id: storeID, Name: "test-store", CreatedAt: sampleTime, UpdatedAt: sampleTime}, nil)
+				setupGetStoreMock(mockCtrl, mockFgaClient, storeID, sampleTime)
 			}
 
-			var err error
-			if storeID != "" {
-				_, err = importStore(&clientConfig, mockFgaClient, &test.testStore, "", test.storeId, 1, 1, "")
-			} else {
-				_, err = importStore(&clientConfig, mockFgaClient, &test.testStore, "", "", 1, 1, "")
-			}
-
+			_, err := importStore(&clientConfig, mockFgaClient, &test.testStore, "", storeID, 1, 1, "")
 			if err != nil {
 				t.Errorf("expected no error, got %v", err)
 			}
-
 		})
 	}
+}
+
+func setupGetStoreMock(
+	mockCtrl *gomock.Controller,
+	mockFgaClient *mockclient.MockSdkClient,
+	storeID string,
+	sampleTime time.Time,
+) {
+	mockGetStore := mockclient.NewMockSdkClientGetStoreRequestInterface(mockCtrl)
+	mockFgaClient.EXPECT().GetStore(context.Background()).Return(mockGetStore)
+	mockGetStore.EXPECT().Execute().Return(
+		&client.ClientGetStoreResponse{Id: storeID, Name: "test-store", CreatedAt: sampleTime, UpdatedAt: sampleTime},
+		nil,
+	)
+}
+
+func setupCreateStoreMock(mockCtrl *gomock.Controller, mockFgaClient *mockclient.MockSdkClient, storeID string) {
+	mockCreateStore := mockclient.NewMockSdkClientCreateStoreRequestInterface(mockCtrl)
+	mockFgaClient.EXPECT().CreateStore(context.Background()).Return(mockCreateStore)
+	mockCreateStore.EXPECT().Body(gomock.Any()).Return(mockCreateStore)
+	mockCreateStore.EXPECT().Execute().Return(&client.ClientCreateStoreResponse{Id: storeID}, nil)
+	mockFgaClient.EXPECT().SetStoreId(storeID)
+}
+
+func setupWriteModelMock(mockCtrl *gomock.Controller, mockFgaClient *mockclient.MockSdkClient, modelID string) {
+	mockWriteModel := mockclient.NewMockSdkClientWriteAuthorizationModelRequestInterface(mockCtrl)
+	mockFgaClient.EXPECT().WriteAuthorizationModel(context.Background()).Return(mockWriteModel)
+	mockWriteModel.EXPECT().Body(gomock.Any()).Return(mockWriteModel)
+	mockWriteModel.EXPECT().Execute().Return(
+		&client.ClientWriteAuthorizationModelResponse{AuthorizationModelId: modelID},
+		nil,
+	)
+}
+
+func setupWriteAssertionsMock(
+	mockCtrl *gomock.Controller,
+	mockFgaClient *mockclient.MockSdkClient,
+	expectedAssertions []client.ClientAssertion,
+	expectedOptions client.ClientWriteAssertionsOptions,
+) {
+	mockWriteAssertions := mockclient.NewMockSdkClientWriteAssertionsRequestInterface(mockCtrl)
+	mockFgaClient.EXPECT().WriteAssertions(context.Background()).Return(mockWriteAssertions)
+	mockWriteAssertions.EXPECT().Body(expectedAssertions).Return(mockWriteAssertions)
+	mockWriteAssertions.EXPECT().Options(expectedOptions).Return(mockWriteAssertions)
+	mockWriteAssertions.EXPECT().Execute().Return(nil, nil)
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
When importing a store, we usually import the model and the tuples from the file. But these changes enable us to also import the assertions (only Check assertions) from the Model Tests as a part of the store import.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
closes https://github.com/openfga/cli/issues/224

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

