### PR TITLE
chore: Update README.md to replace import by write command when importing tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ type document
 | [Delete Relationship Tuples](#delete-relationship-tuples)                         | `delete`  | `--store-id`, `--model-id`           | `fga tuple delete user:anne can_view document:roadmap --store-id=01H0H015178Y2V4CX10C2KGHF4`                                                          |
 | [Read Relationship Tuples](#read-relationship-tuples)                             | `read`    | `--store-id`, `--model-id`           | `fga tuple read --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1`                      |
 | [Read Relationship Tuple Changes (Watch)](#read-relationship-tuple-changes-watch) | `changes` | `--store-id`, `--type`, `--start-time`, `--continuation-token`,           | `fga tuple changes --store-id=01H0H015178Y2V4CX10C2KGHF4 --type=document --start-time=2022-01-01T00:00:00Z --continuation-token=M3w=`                   |
-| [Import Relationship Tuples](#import-relationship-tuples)                        | `import`  | `--store-id`, `--model-id`, `--file` | `fga tuple import --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1 --file tuples.json` |
+| [Import Relationship Tuples](#import-relationship-tuples)                        | `write`  | `--store-id`, `--model-id`, `--file` | `fga tuple write --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1 --file tuples.json` |
 
 ##### Write Relationship Tuples
 
@@ -891,11 +891,11 @@ fga tuple **read** [--user=<user>] [--relation=<relation>] [--object=<object>]  
 ```
 
 
-If you want to transform this output in a way that can be then imported using the `fga tuple import` you can run
+If you want to transform this output in a way that can be then imported using the `fga tuple write` you can run
 
 ```
 fga tuple read --output-format=simple-json --max-pages 0 > tuples.json
-fga tuple import --file tuples.json
+fga tuple write --file tuples.json
 ```
 
 ##### Read Relationship Tuple Changes (Watch)
@@ -969,7 +969,7 @@ In JSON:
 ```
 
 ###### Example
-`fga tuple import --store-id=01H0H015178Y2V4CX10C2KGHF4 --file tuples.json`
+`fga tuple write --store-id=01H0H015178Y2V4CX10C2KGHF4 --file tuples.json`
 
 ###### Response
 ```json5

--- a/README.md
+++ b/README.md
@@ -652,11 +652,10 @@ type document
 
 | Description                                                                       | command   | parameters                           | example                                                                                                           |
 |-----------------------------------------------------------------------------------|-----------|--------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| [Write Relationship Tuples](#write-relationship-tuples)                           | `write`   | `--store-id`, `--model-id`           | `fga tuple write user:anne can_view document:roadmap --store-id=01H0H015178Y2V4CX10C2KGHF4`        |
+| [Write Relationship Tuples](#write-relationship-tuples)                           | `write`   | `--store-id`, `--model-id` `--file`          | `fga tuple write user:anne can_view document:roadmap --store-id=01H0H015178Y2V4CX10C2KGHF4`        |
 | [Delete Relationship Tuples](#delete-relationship-tuples)                         | `delete`  | `--store-id`, `--model-id`           | `fga tuple delete user:anne can_view document:roadmap --store-id=01H0H015178Y2V4CX10C2KGHF4`                                                          |
 | [Read Relationship Tuples](#read-relationship-tuples)                             | `read`    | `--store-id`, `--model-id`           | `fga tuple read --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1`                      |
 | [Read Relationship Tuple Changes (Watch)](#read-relationship-tuple-changes-watch) | `changes` | `--store-id`, `--type`, `--start-time`, `--continuation-token`,           | `fga tuple changes --store-id=01H0H015178Y2V4CX10C2KGHF4 --type=document --start-time=2022-01-01T00:00:00Z --continuation-token=M3w=`                   |
-| [Import Relationship Tuples](#import-relationship-tuples)                        | `write`  | `--store-id`, `--model-id`, `--file` | `fga tuple write --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1 --file tuples.json` |
 
 ##### Write Relationship Tuples
 
@@ -679,6 +678,7 @@ fga tuple **write** <user> <relation> <object> --store-id=<store-id>
 ###### Example (with arguments)
 - `fga tuple write --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne can_view document:roadmap`
 - `fga tuple write --store-id=01H0H015178Y2V4CX10C2KGHF4 user:anne can_view document:roadmap --condition-name inOffice --condition-context '{"office_ip":"10.0.1.10"}'`
+- `fga tuple write --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1 --file tuples.json`
 
 ###### Response
 ```json5
@@ -928,69 +928,6 @@ fga tuple **changes** --type <type> --store-id=<store-id>
     }
   ],
   "continuation_token":"NHw="
-}
-```
-
-##### Import Relationship Tuples
-
-###### Command
-fga tuple **import** --store-id=<store-id> [--model-id=<model-id>] --file <filename> [--max-tuples-per-write=<num>] [--max-parallel-requests=<num>]
-
-###### Parameters
-* `--store-id`: Specifies the store id
-* `--model-id`: Specifies the model id to target (optional)
-* `--file`: Specifies the file name, `yaml` and `json` files are supported
-* `--max-tuples-per-write`: Max tuples to send in a single write (optional, default=1)
-* `--max-parallel-requests`: Max requests to send in parallel (optional, default=4)
-
-File format should be:
-In YAML:
-```yaml
-- user: user:anne
-  relation: can_view
-  object: document:roadmap
-- user: user:beth
-  relation: can_view
-  object: document:roadmap
-```
-
-In JSON:
-
-```json
-[{
-  "user": "user:anne",
-  "relation": "can_view",
-  "object": "document:roadmap"
-}, {
-  "user": "user:beth",
-  "relation": "can_view",
-  "object": "document:roadmap"
-}]
-```
-
-###### Example
-`fga tuple write --store-id=01H0H015178Y2V4CX10C2KGHF4 --file tuples.json`
-
-###### Response
-```json5
-{
-  "successful": [
-    {
-      "object":"document:roadmap",
-      "relation":"writer",
-      "user":"user:annie"
-    }
-  ],
-  "failed": [
-    {
-      "tuple_key": {
-        "object":"document:roadmap",
-        "relation":"writer",
-        "user":"carl"
-      },
-      "reason":"Write validation error ..."
-    }
-  ]
 }
 ```
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This PR replaces instances of `tuple import` (deprecated) by `tuple write` and avoid getting the warning when following the README instructions 

```
Command "import" is deprecated, use the write/delete command with the flag --file instead
```



## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

