### PR TITLE
Add RPS control with ramp-up for tuple writes

### DIFF
--- a/cmd/tuple/delete.go
+++ b/cmd/tuple/delete.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tuple
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -60,7 +59,7 @@ var deleteCmd = &cobra.Command{
 				return fmt.Errorf("failed to parse input tuples due to %w", err)
 			}
 
-			// Convert ClientTupleKeyWithoutCondition to ClientTupleKey
+			// Convert ClientTupleKey to ClientTupleKeyWithoutCondition
 			tuples := make([]client.ClientTupleKey, len(tuplesWithoutCondition))
 			for i, t := range tuplesWithoutCondition {
 				tuples[i] = client.ClientTupleKey{
@@ -107,8 +106,18 @@ var deleteCmd = &cobra.Command{
 				}
 			}
 
+			// Convert ClientTupleKey to ClientTupleKeyWithoutCondition
+			tuplesWithoutCondition = make([]client.ClientTupleKeyWithoutCondition, len(tuples))
+			for i, t := range tuples {
+				tuplesWithoutCondition[i] = client.ClientTupleKeyWithoutCondition{
+					User:     t.User,
+					Relation: t.Relation,
+					Object:   t.Object,
+				}
+			}
+
 			deleteRequest := client.ClientWriteRequest{
-				Deletes: tuples,
+				Deletes: tuplesWithoutCondition,
 			}
 			response, err := ImportTuples(fgaClient, deleteRequest, maxTuplesPerWrite, maxParallelRequests, minRPS, maxRPS, rampupPeriod)
 			if err != nil {
@@ -118,8 +127,8 @@ var deleteCmd = &cobra.Command{
 			return output.Display(*response)
 		}
 
-		// Create a ClientTupleKey from the arguments
-		tupleKey := client.ClientTupleKey{
+		// Create a ClientTupleKeyWithoutCondition from the arguments
+		tupleKey := client.ClientTupleKeyWithoutCondition{
 			User:     args[0],
 			Relation: args[1],
 			Object:   args[2],
@@ -127,7 +136,7 @@ var deleteCmd = &cobra.Command{
 
 		// Create a delete request with the tuple
 		deleteRequest := client.ClientWriteRequest{
-			Deletes: []client.ClientTupleKey{tupleKey},
+			Deletes: []client.ClientTupleKeyWithoutCondition{tupleKey},
 		}
 
 		// Extract RPS control parameters

--- a/cmd/tuple/import.go
+++ b/cmd/tuple/import.go
@@ -18,9 +18,11 @@ package tuple
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
@@ -59,6 +61,9 @@ func ImportTuples(
 	body client.ClientWriteRequest,
 	maxTuplesPerWrite int32,
 	maxParallelRequests int32,
+	minRPS int32,
+	maxRPS int32,
+	rampupPeriodInSec int32,
 ) (*ImportResponse, error) {
 	options := client.ClientWriteOptions{
 		Transaction: &client.TransactionOptions{
@@ -68,13 +73,137 @@ func ImportTuples(
 		},
 	}
 
-	response, err := fgaClient.Write(context.Background()).Body(body).Options(options).Execute()
-	if err != nil {
-		return nil, fmt.Errorf("failed to import tuples due to %w", err)
+	// If RPS control is not enabled, use the standard write method
+	if minRPS <= 0 || maxRPS <= 0 || rampupPeriodInSec <= 0 {
+		response, err := fgaClient.Write(context.Background()).Body(body).Options(options).Execute()
+		if err != nil {
+			return nil, fmt.Errorf("failed to import tuples due to %w", err)
+		}
+
+		successfulWrites, failedWrites := processWrites(response.Writes)
+		successfulDeletes, failedDeletes := processDeletes(response.Deletes)
+
+		result := ImportResponse{
+			Successful: append(successfulWrites, successfulDeletes...),
+			Failed:     append(failedWrites, failedDeletes...),
+		}
+
+		return &result, nil
 	}
 
-	successfulWrites, failedWrites := processWrites(response.Writes)
-	successfulDeletes, failedDeletes := processDeletes(response.Deletes)
+	// RPS control is enabled, implement rate-limited writes with ramp-up
+	return importTuplesWithRateLimit(fgaClient, body, options, minRPS, maxRPS, rampupPeriodInSec)
+}
+
+// importTuplesWithRateLimit imports tuples with rate limiting and ramp-up
+func importTuplesWithRateLimit(
+	fgaClient client.SdkClient,
+	body client.ClientWriteRequest,
+	options client.ClientWriteOptions,
+	minRPS int32,
+	maxRPS int32,
+	rampupPeriodInSec int32,
+) (*ImportResponse, error) {
+	ctx := context.Background()
+
+	// Prepare result containers
+	var successfulWrites []client.ClientTupleKey
+	var failedWrites []failedWriteResponse
+	var successfulDeletes []client.ClientTupleKey
+	var failedDeletes []failedWriteResponse
+
+	// Calculate total number of tuples to write
+	totalTuples := len(body.Writes) + len(body.Deletes)
+	if totalTuples == 0 {
+		return &ImportResponse{
+			Successful: []client.ClientTupleKey{},
+			Failed:     []failedWriteResponse{},
+		}, nil
+	}
+
+	// Create batches of tuples to write
+	// Each batch will contain a single tuple for now
+	// This could be optimized in the future to use maxTuplesPerWrite
+	var writeBatches []client.ClientWriteRequest
+
+	// Add write tuples to batches
+	for _, tuple := range body.Writes {
+		writeBatches = append(writeBatches, client.ClientWriteRequest{
+			Writes: []client.ClientTupleKey{tuple},
+		})
+	}
+
+	// Add delete tuples to batches
+	for _, tuple := range body.Deletes {
+		writeBatches = append(writeBatches, client.ClientWriteRequest{
+			Deletes: []client.ClientTupleKey{tuple},
+		})
+	}
+
+	// Calculate ramp-up parameters
+	rampupPeriod := time.Duration(rampupPeriodInSec) * time.Second
+	startTime := time.Now()
+	endRampupTime := startTime.Add(rampupPeriod)
+
+	// Process each batch with rate limiting
+	for i, batch := range writeBatches {
+		// Calculate current RPS based on elapsed time and ramp-up period
+		currentTime := time.Now()
+		if currentTime.After(endRampupTime) {
+			// Ramp-up period has passed, use max RPS
+			time.Sleep(time.Second / time.Duration(maxRPS))
+		} else {
+			// Still in ramp-up period, calculate current RPS
+			elapsedRatio := float64(currentTime.Sub(startTime)) / float64(rampupPeriod)
+			currentRPS := minRPS + int32(float64(maxRPS-minRPS)*elapsedRatio)
+			if currentRPS < minRPS {
+				currentRPS = minRPS
+			}
+			if currentRPS > maxRPS {
+				currentRPS = maxRPS
+			}
+
+			// Sleep to maintain the current RPS
+			time.Sleep(time.Second / time.Duration(currentRPS))
+		}
+
+		// Execute the write request
+		response, err := fgaClient.Write(ctx).Body(batch).Options(options).Execute()
+		if err != nil {
+			// If the entire request failed, add all tuples in this batch to failed
+			if len(batch.Writes) > 0 {
+				for _, tuple := range batch.Writes {
+					failedWrites = append(failedWrites, failedWriteResponse{
+						TupleKey: tuple,
+						Reason:   extractErrMssg(err),
+					})
+				}
+			}
+			if len(batch.Deletes) > 0 {
+				for _, tuple := range batch.Deletes {
+					failedDeletes = append(failedDeletes, failedWriteResponse{
+						TupleKey: tuple,
+						Reason:   extractErrMssg(err),
+					})
+				}
+			}
+			continue
+		}
+
+		// Process successful and failed writes/deletes
+		sw, fw := processWrites(response.Writes)
+		successfulWrites = append(successfulWrites, sw...)
+		failedWrites = append(failedWrites, fw...)
+
+		sd, fd := processDeletes(response.Deletes)
+		successfulDeletes = append(successfulDeletes, sd...)
+		failedDeletes = append(failedDeletes, fd...)
+
+		// Log progress (optional)
+		if i > 0 && i%100 == 0 {
+			fmt.Fprintf(os.Stderr, "Processed %d/%d tuples\n", i, totalTuples)
+		}
+	}
 
 	result := ImportResponse{
 		Successful: append(successfulWrites, successfulDeletes...),
@@ -156,7 +285,19 @@ var importCmd = &cobra.Command{
 	Short:      "Import Relationship Tuples",
 	Deprecated: "use the write/delete command with the flag --file instead",
 	Long: "Imports Relationship Tuples to the store. " +
-		"This will write the tuples in chunks and at the end will report the tuple chunks that failed.",
+		"This will write the tuples in chunks and at the end will report the tuple chunks that failed.\n\n" +
+		"Rate Limiting:\n" +
+		"You can control the rate at which tuples are written using the following flags:\n" +
+		"- min-rps: Minimum requests per second for writes\n" +
+		"- max-rps: Maximum requests per second for writes\n" +
+		"- rampup-period-in-sec: Period in seconds to ramp up from min-rps to max-rps\n\n" +
+		"If any of these flags are provided, all three must be provided with positive values. " +
+		"The command will start writing tuples at the min-rps rate and gradually increase to " +
+		"max-rps over the specified rampup period. If all tuples are written before the rampup " +
+		"period ends, the command will exit. If the rampup period ends and there are still tuples " +
+		"to write, the command will continue writing at the max-rps rate until all tuples are written.",
+	Example: `  fga tuple import --store-id=01H0H015178Y2V4CX10C2KGHF4 --file tuples.yaml
+  fga tuple import --store-id=01H0H015178Y2V4CX10C2KGHF4 --file tuples.yaml --min-rps=10 --max-rps=50 --rampup-period-in-sec=60`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		clientConfig := cmdutils.GetClientConfig(cmd)
 
@@ -180,6 +321,33 @@ var importCmd = &cobra.Command{
 			return fmt.Errorf("failed to parse parallel requests due to %w", err)
 		}
 
+		// Extract RPS control parameters
+		minRPS, err := cmd.Flags().GetInt32("min-rps")
+		if err != nil {
+			return fmt.Errorf("failed to parse min-rps: %w", err)
+		}
+
+		maxRPS, err := cmd.Flags().GetInt32("max-rps")
+		if err != nil {
+			return fmt.Errorf("failed to parse max-rps: %w", err)
+		}
+
+		rampupPeriod, err := cmd.Flags().GetInt32("rampup-period-in-sec")
+		if err != nil {
+			return fmt.Errorf("failed to parse rampup-period-in-sec: %w", err)
+		}
+
+		// Validate RPS parameters - if one is provided, all three should be required
+		if minRPS > 0 || maxRPS > 0 || rampupPeriod > 0 {
+			if minRPS <= 0 || maxRPS <= 0 || rampupPeriod <= 0 {
+				return errors.New("if any of min-rps, max-rps, or rampup-period-in-sec is provided, all three must be provided with positive values") //nolint:goerr113
+			}
+
+			if minRPS > maxRPS {
+				return errors.New("min-rps cannot be greater than max-rps") //nolint:goerr113
+			}
+		}
+
 		tuples := []client.ClientTupleKey{}
 
 		data, err := os.ReadFile(fileName)
@@ -196,7 +364,7 @@ var importCmd = &cobra.Command{
 			Writes: tuples,
 		}
 
-		result, err := ImportTuples(fgaClient, writeRequest, maxTuplesPerWrite, maxParallelRequests)
+		result, err := ImportTuples(fgaClient, writeRequest, maxTuplesPerWrite, maxParallelRequests, minRPS, maxRPS, rampupPeriod)
 		if err != nil {
 			return err
 		}
@@ -210,4 +378,7 @@ func init() {
 	importCmd.Flags().String("file", "", "Tuples file")
 	importCmd.Flags().Int32("max-tuples-per-write", MaxTuplesPerWrite, "Max tuples per write chunk.")
 	importCmd.Flags().Int32("max-parallel-requests", MaxParallelRequests, "Max number of requests to issue to the server in parallel.") //nolint:lll
+	importCmd.Flags().Int32("min-rps", 0, "Minimum requests per second for writes")
+	importCmd.Flags().Int32("max-rps", 0, "Maximum requests per second for writes")
+	importCmd.Flags().Int32("rampup-period-in-sec", 0, "Period in seconds to ramp up from min-rps to max-rps")
 }

--- a/cmd/tuple/import.go
+++ b/cmd/tuple/import.go
@@ -42,8 +42,8 @@ const (
 )
 
 type failedWriteResponse struct {
-	TupleKey client.ClientTupleKey `json:"tuple_key"`
-	Reason   string                `json:"reason"`
+	TupleKey interface{} `json:"tuple_key"`
+	Reason   string      `json:"reason"`
 }
 
 type ImportResponse struct {
@@ -128,16 +128,34 @@ func importTuplesWithRateLimit(
 
 	// Add write tuples to batches
 	for _, tuple := range body.Writes {
-		writeBatches = append(writeBatches, client.ClientWriteRequest{
-			Writes: []client.ClientTupleKey{tuple},
-		})
+		// Convert to ClientTupleKeyWithoutCondition if needed
+		tupleWithoutCondition, ok := tuple.(client.ClientTupleKeyWithoutCondition)
+		if ok {
+			writeBatches = append(writeBatches, client.ClientWriteRequest{
+				Writes: []client.ClientTupleKeyWithoutCondition{tupleWithoutCondition},
+			})
+		} else {
+			// Assume it's already a ClientTupleKey
+			writeBatches = append(writeBatches, client.ClientWriteRequest{
+				Writes: []client.ClientTupleKey{tuple},
+			})
+		}
 	}
 
 	// Add delete tuples to batches
 	for _, tuple := range body.Deletes {
-		writeBatches = append(writeBatches, client.ClientWriteRequest{
-			Deletes: []client.ClientTupleKey{tuple},
-		})
+		// Convert to ClientTupleKeyWithoutCondition if needed
+		tupleWithoutCondition, ok := tuple.(client.ClientTupleKeyWithoutCondition)
+		if ok {
+			writeBatches = append(writeBatches, client.ClientWriteRequest{
+				Deletes: []client.ClientTupleKeyWithoutCondition{tupleWithoutCondition},
+			})
+		} else {
+			// Assume it's already a ClientTupleKey
+			writeBatches = append(writeBatches, client.ClientWriteRequest{
+				Deletes: []client.ClientTupleKey{tuple},
+			})
+		}
 	}
 
 	// Calculate ramp-up parameters

--- a/cmd/tuple/write.go
+++ b/cmd/tuple/write.go
@@ -107,23 +107,21 @@ func writeTuplesFromArgs(cmd *cobra.Command, args []string, fgaClient *client.Op
 
 	if condition == nil {
 		// Use ClientTupleKeyWithoutCondition if there's no condition
-		body = client.ClientWriteTuplesBody{
-			client.ClientTupleKeyWithoutCondition{
-				User:     args[0],
-				Relation: args[1],
-				Object:   args[2],
-			},
+		tupleWithoutCondition := client.ClientTupleKeyWithoutCondition{
+			User:     args[0],
+			Relation: args[1],
+			Object:   args[2],
 		}
+		body = []client.ClientTupleKeyWithoutCondition{tupleWithoutCondition}
 	} else {
 		// Use ClientTupleKey if there's a condition
-		body = client.ClientWriteTuplesBody{
-			client.ClientTupleKey{
-				User:      args[0],
-				Relation:  args[1],
-				Object:    args[2],
-				Condition: condition,
-			},
+		tupleKey := client.ClientTupleKey{
+			User:      args[0],
+			Relation:  args[1],
+			Object:    args[2],
+			Condition: condition,
 		}
+		body = []client.ClientTupleKey{tupleKey}
 	}
 
 	_, err = fgaClient.

--- a/cmd/tuple/write.go
+++ b/cmd/tuple/write.go
@@ -103,13 +103,27 @@ func writeTuplesFromArgs(cmd *cobra.Command, args []string, fgaClient *client.Op
 		return err //nolint:wrapcheck
 	}
 
-	body := client.ClientWriteTuplesBody{
-		client.ClientTupleKey{
-			User:      args[0],
-			Relation:  args[1],
-			Object:    args[2],
-			Condition: condition,
-		},
+	var body client.ClientWriteTuplesBody
+
+	if condition == nil {
+		// Use ClientTupleKeyWithoutCondition if there's no condition
+		body = client.ClientWriteTuplesBody{
+			client.ClientTupleKeyWithoutCondition{
+				User:     args[0],
+				Relation: args[1],
+				Object:   args[2],
+			},
+		}
+	} else {
+		// Use ClientTupleKey if there's a condition
+		body = client.ClientWriteTuplesBody{
+			client.ClientTupleKey{
+				User:      args[0],
+				Relation:  args[1],
+				Object:    args[2],
+				Condition: condition,
+			},
+		}
 	}
 
 	_, err = fgaClient.


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

This PR adds support for specifying RPS (Requests Per Second) for writes while allowing for ramp-up over a period of time. It implements the following features:

- Adds three new flags to the `tuple write` and `tuple import` commands:
  - `min-rps`: Minimum requests per second for writes
  - `max-rps`: Maximum requests per second for writes
  - `rampup-period-in-sec`: Period in seconds to ramp up from min-rps to max-rps

- These flags are optional by default, but if one is provided, all three are required with positive values

- When these flags are provided, the SDK:
  - Starts writing tuples at the min-rps rate
  - Gradually increases to max-rps over the specified rampup period
  - If all tuples are written before the rampup period ends, the command exits
  - If the rampup period ends and there are still tuples to write, the command continues writing at the max-rps rate until all tuples are written

## Testing

Added a test case to verify the RPS control functionality. The test ensures that:
- The rate limiting works as expected
- The duration of the write operation is consistent with the specified RPS parameters


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

fixes #463

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

