### PR TITLE
chore: migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ jobs:
         check-latest: true
         go-version: ${{ env.GO_VERSION }}
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
         version: latest
         args: -v -c .golangci.yaml
@@ -114,7 +114,7 @@ jobs:
     - uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
+      uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
       with:
         distribution: goreleaser
         version: '~> v2'
@@ -190,7 +190,7 @@ jobs:
         id: hashes
         with:
           path: digests.txt
-  
+
       - name: Image digest
         id: image
         env:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,29 +1,24 @@
 version: "2"
-
 run:
-  timeout: 3m
   modules-download-mode: readonly
   allow-parallel-runners: true
-
 linters:
   default: all
   disable:
-    - dupl #temporary
+    - dupl
     - exhaustruct
-    - gochecknoinits
     - forbidigo
     - gochecknoglobals
-    # deprecated
+    - gochecknoinits
+    - mnd
     - testpackage
-    - gci
-    - gomnd
   settings:
     depguard:
       rules:
         main:
           files:
             - $all
-            - "!$test"
+            - '!$test'
           allow:
             - $gostd
             - github.com/gocarina/gocsv
@@ -49,7 +44,7 @@ linters:
             - gopkg.in/yaml.v3
         test:
           files:
-            - "$test"
+            - $test
           allow:
             - $gostd
             - github.com/golang/mock/gomock
@@ -59,17 +54,21 @@ linters:
             - github.com/openfga/openfga
             - github.com/stretchr
             - go.uber.org/mock/gomock
-
-    tagliatelle:
-      case:
-        use-field-name: true
-        rules:
-          json: snake
-
     funlen:
       lines: 120
       statements: 80
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+        use-field-name: true
   exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
       - linters:
           - lll
@@ -77,19 +76,24 @@ linters:
       - linters:
           - err113
           - funlen
+          - lll
         path: _test.go
-
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 formatters:
   enable:
+    - gofmt
+    - gofumpt
     - goimports
   settings:
     goimports:
-      local-prefixes: ["github.com/openfga/cli"]
-
-output:
-  formats:
-    text:
-      path: stdout
-      print-issued-lines: true
-      print-linter-name: true
-      colors: true
+      local-prefixes:
+        - github.com/openfga/cli
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,10 +1,12 @@
+version: "2"
+
 run:
   timeout: 3m
   modules-download-mode: readonly
   allow-parallel-runners: true
 
 linters:
-  enable-all: true
+  default: all
   disable:
     - dupl #temporary
     - exhaustruct

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,16 +70,19 @@ linters:
       lines: 120
       statements: 80
 
+formatters:
+  enable:
+    - goimports
+  settings:
     goimports:
       local-prefixes: "github.com/openfga/cli"
 
-issues:
-  exclude:
-    - path: "cmd/tuple/write(.*).go"
-      linters:
-        - lll
-    - path: _test.go
-      linters:
-        - err113
-        - funlen
-        - lll
+exclude:
+  - path: "cmd/tuple/write(.*).go"
+    linters:
+      - lll
+  - path: _test.go
+    linters:
+      - err113
+      - funlen
+      - lll

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,7 +17,8 @@ linters:
     - testpackage
     - gci
     - gomnd
-linters-settings:
+
+settings:
   depguard:
     rules:
       main:
@@ -73,14 +74,12 @@ linters-settings:
   goimports:
     local-prefixes: "github.com/openfga/cli"
 
-issues:
-  exclude-use-default: true
-  exclude-rules:
-    - path: "cmd/tuple/write(.*).go"
-      linters:
-        - lll
-    - path: _test.go
-      linters:
-        - err113
-        - funlen
-        - lll
+exclude:
+  - path: "cmd/tuple/write(.*).go"
+    linters:
+      - lll
+  - path: _test.go
+    linters:
+      - err113
+      - funlen
+      - lll

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -77,8 +77,16 @@ formatters:
     goimports:
       local-prefixes: ["github.com/openfga/cli"]
 
+output:
+  formats:
+    text:
+      path: stdout
+      print-issued-lines: true
+      print-linter-name: true
+      colors: true
+
 issues:
-  exclude:
+  exclude-rules:
     - path: "cmd/tuple/write(.*).go"
       linters:
         - lll

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -85,13 +85,12 @@ output:
       print-linter-name: true
       colors: true
 
-issues:
-  exclude-rules:
-    - path: "cmd/tuple/write(.*).go"
-      linters:
-        - lll
-    - path: _test.go
-      linters:
-        - err113
-        - funlen
-        - lll
+exclude:
+  - path: "cmd/tuple/write(.*).go"
+    linters:
+      - lll
+  - path: _test.go
+    linters:
+      - err113
+      - funlen
+      - lll

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,69 +17,69 @@ linters:
     - testpackage
     - gci
     - gomnd
-
-settings:
-  depguard:
-    rules:
-      main:
-        files:
-          - $all
-          - "!$test"
-        allow:
-          - $gostd
-          - github.com/gocarina/gocsv
-          - github.com/hashicorp/go-multierror
-          - github.com/mattn/go-isatty
-          - github.com/muesli/mango-cobra
-          - github.com/muesli/roff
-          - github.com/nwidger/jsoncolor
-          - github.com/oklog/ulid/v2
-          - github.com/openfga/api
-          - github.com/openfga/cli
-          - github.com/openfga/go-sdk
-          - github.com/openfga/language
-          - github.com/openfga/openfga
-          - github.com/rung/go-safecast
-          - github.com/schollz/progressbar/v3
-          - github.com/spf13/cobra
-          - github.com/spf13/pflag
-          - github.com/spf13/viper
-          - golang.org/x/time/rate
-          - google.golang.org/protobuf/encoding/protojson
-          - google.golang.org/protobuf/types/known/structpb
-          - gopkg.in/yaml.v3
-      test:
-        files:
-          - "$test"
-        allow:
-          - $gostd
-          - github.com/golang/mock/gomock
-          - github.com/openfga/api/proto
-          - github.com/openfga/cli
-          - github.com/openfga/go-sdk
-          - github.com/openfga/openfga
-          - github.com/stretchr
-          - go.uber.org/mock/gomock
-
-  tagliatelle:
-    case:
-      use-field-name: true
+  settings:
+    depguard:
       rules:
-        json: snake
+        main:
+          files:
+            - $all
+            - "!$test"
+          allow:
+            - $gostd
+            - github.com/gocarina/gocsv
+            - github.com/hashicorp/go-multierror
+            - github.com/mattn/go-isatty
+            - github.com/muesli/mango-cobra
+            - github.com/muesli/roff
+            - github.com/nwidger/jsoncolor
+            - github.com/oklog/ulid/v2
+            - github.com/openfga/api
+            - github.com/openfga/cli
+            - github.com/openfga/go-sdk
+            - github.com/openfga/language
+            - github.com/openfga/openfga
+            - github.com/rung/go-safecast
+            - github.com/schollz/progressbar/v3
+            - github.com/spf13/cobra
+            - github.com/spf13/pflag
+            - github.com/spf13/viper
+            - golang.org/x/time/rate
+            - google.golang.org/protobuf/encoding/protojson
+            - google.golang.org/protobuf/types/known/structpb
+            - gopkg.in/yaml.v3
+        test:
+          files:
+            - "$test"
+          allow:
+            - $gostd
+            - github.com/golang/mock/gomock
+            - github.com/openfga/api/proto
+            - github.com/openfga/cli
+            - github.com/openfga/go-sdk
+            - github.com/openfga/openfga
+            - github.com/stretchr
+            - go.uber.org/mock/gomock
 
-  funlen:
-    lines: 120
-    statements: 80
+    tagliatelle:
+      case:
+        use-field-name: true
+        rules:
+          json: snake
 
-  goimports:
-    local-prefixes: "github.com/openfga/cli"
+    funlen:
+      lines: 120
+      statements: 80
 
-exclude:
-  - path: "cmd/tuple/write(.*).go"
-    linters:
-      - lll
-  - path: _test.go
-    linters:
-      - err113
-      - funlen
-      - lll
+    goimports:
+      local-prefixes: "github.com/openfga/cli"
+
+issues:
+  exclude:
+    - path: "cmd/tuple/write(.*).go"
+      linters:
+        - lll
+    - path: _test.go
+      linters:
+        - err113
+        - funlen
+        - lll

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,13 +70,13 @@ linters:
       lines: 120
       statements: 80
   exclusions:
-    paths:
-      - "cmd/tuple/write(.*).go"
-      - "_test.go"
-    linters:
-      - lll
-      - err113
-      - funlen
+    - path: "cmd/tuple/write(.*).go"
+      linters:
+        - lll
+    - path: "_test.go"
+      linters:
+        - err113
+        - funlen
 
 formatters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,13 +70,14 @@ linters:
       lines: 120
       statements: 80
   exclusions:
-    - path: "cmd/tuple/write(.*).go"
-      linters:
-        - lll
-    - path: "_test.go"
-      linters:
-        - err113
-        - funlen
+    rules:
+      - linters:
+          - lll
+        path: cmd/tuple/write(.*).go
+      - linters:
+          - err113
+          - funlen
+        path: _test.go
 
 formatters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,14 +70,13 @@ linters:
       lines: 120
       statements: 80
   exclusions:
-    - path: "cmd/tuple/write(.*).go"
-      linters:
-        - lll
-    - path: _test.go
-      linters:
-        - err113
-        - funlen
-        - lll
+    paths:
+      - "cmd/tuple/write(.*).go"
+      - "_test.go"
+    linters:
+      - lll
+      - err113
+      - funlen
 
 formatters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -69,6 +69,15 @@ linters:
     funlen:
       lines: 120
       statements: 80
+  exclusions:
+    - path: "cmd/tuple/write(.*).go"
+      linters:
+        - lll
+    - path: _test.go
+      linters:
+        - err113
+        - funlen
+        - lll
 
 formatters:
   enable:
@@ -84,13 +93,3 @@ output:
       print-issued-lines: true
       print-linter-name: true
       colors: true
-
-exclude:
-  - path: "cmd/tuple/write(.*).go"
-    linters:
-      - lll
-  - path: _test.go
-    linters:
-      - err113
-      - funlen
-      - lll

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -75,14 +75,15 @@ formatters:
     - goimports
   settings:
     goimports:
-      local-prefixes: "github.com/openfga/cli"
+      local-prefixes: ["github.com/openfga/cli"]
 
-exclude:
-  - path: "cmd/tuple/write(.*).go"
-    linters:
-      - lll
-  - path: _test.go
-    linters:
-      - err113
-      - funlen
-      - lll
+issues:
+  exclude:
+    - path: "cmd/tuple/write(.*).go"
+      linters:
+        - lll
+    - path: _test.go
+      linters:
+        - err113
+        - funlen
+        - lll

--- a/cmd/model/transform.go
+++ b/cmd/model/transform.go
@@ -54,7 +54,7 @@ fga model transform --file=fga.mod`,
 		if transformOutputFormat != authorizationmodel.ModelFormatDefault &&
 			transformOutputFormat != authorizationmodel.ModelFormatFGA &&
 			transformOutputFormat != authorizationmodel.ModelFormatJSON {
-			return fmt.Errorf( //nolint:goerr113
+			return fmt.Errorf( //nolint:err113
 				`unsupported output format %s, supported formats are "fga" and "json"`,
 				transformOutputFormat,
 			)

--- a/cmd/store/create.go
+++ b/cmd/store/create.go
@@ -58,7 +58,7 @@ func CreateStoreWithModel(
 	response := CreateStoreAndModelResponse{}
 
 	if storeName == "" {
-		return nil, errors.New(`required flag(s) "name" not set`) //nolint:goerr113
+		return nil, errors.New(`required flag(s) "name" not set`) //nolint:err113
 	}
 
 	createStoreResponse, err := create(ctx, fgaClient, storeName)
@@ -97,7 +97,7 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create Store",
 	Long:  "Create an OpenFGA store.",
-	Example: `fga store create --name "FGA Demo Store" 
+	Example: `fga store create --name "FGA Demo Store"
 
 To set the created store id as an environment variable that will be used by the CLI, you can use the following command:
 

--- a/cmd/tuple/delete.go
+++ b/cmd/tuple/delete.go
@@ -134,7 +134,7 @@ func init() {
 func ExactArgsOrFlag(n int, flag string) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) != n && !cmd.Flags().Changed(flag) {
-			return fmt.Errorf("at least %d arg(s) are required OR the flag --%s", n, flag) //nolint:goerr113
+			return fmt.Errorf("at least %d arg(s) are required OR the flag --%s", n, flag) //nolint:err113
 		}
 
 		return nil

--- a/cmd/tuple/write.go
+++ b/cmd/tuple/write.go
@@ -131,7 +131,7 @@ func writeTuplesFromFile(ctx context.Context, flags *flag.FlagSet, fgaClient *cl
 	}
 
 	if fileName == "" {
-		return errors.New("file name cannot be empty") //nolint:goerr113
+		return errors.New("file name cannot be empty") //nolint:err113
 	}
 
 	maxTuplesPerWrite, err := flags.GetInt("max-tuples-per-write")

--- a/internal/authorizationmodel/read-from-input.go
+++ b/internal/authorizationmodel/read-from-input.go
@@ -42,7 +42,7 @@ func ReadFromFile(
 	*input = string(file)
 
 	// if the input format is set as the default, set it from the file extension (and default to fga)
-	//nolint:staticcheck,exhaustive
+	//nolint:staticcheck
 	if *format == ModelFormatDefault {
 		switch {
 		case strings.HasSuffix(fileName, "fga.mod"):

--- a/internal/authorizationmodel/read-from-input.go
+++ b/internal/authorizationmodel/read-from-input.go
@@ -57,6 +57,10 @@ func ReadFromFile(
 		// If we're provided a modular model we want the input to be the filename as we will handle
 		// reading and parsing the fga.mod file later
 		*input = fileName
+	case ModelFormatJSON:
+		// No special handling needed for JSON format
+	case ModelFormatFGA:
+		// No special handling needed for FGA format
 	}
 
 	if *storeName == "" {

--- a/internal/authorizationmodel/read-from-input.go
+++ b/internal/authorizationmodel/read-from-input.go
@@ -42,8 +42,8 @@ func ReadFromFile(
 	*input = string(file)
 
 	// if the input format is set as the default, set it from the file extension (and default to fga)
-	switch *format {
-	case ModelFormatDefault:
+	// nolint:staticcheck,exhaustive
+	if *format == ModelFormatDefault {
 		switch {
 		case strings.HasSuffix(fileName, "fga.mod"):
 			*format = ModelFormatModular
@@ -53,14 +53,10 @@ func ReadFromFile(
 		default:
 			*format = ModelFormatFGA
 		}
-	case ModelFormatModular:
+	} else if *format == ModelFormatModular {
 		// If we're provided a modular model we want the input to be the filename as we will handle
 		// reading and parsing the fga.mod file later
 		*input = fileName
-	case ModelFormatJSON:
-		// No special handling needed for JSON format
-	case ModelFormatFGA:
-		// No special handling needed for FGA format
 	}
 
 	if *storeName == "" {

--- a/internal/authorizationmodel/read-from-input.go
+++ b/internal/authorizationmodel/read-from-input.go
@@ -42,8 +42,8 @@ func ReadFromFile(
 	*input = string(file)
 
 	// if the input format is set as the default, set it from the file extension (and default to fga)
-	switch {
-	case *format == ModelFormatDefault:
+	switch *format {
+	case ModelFormatDefault:
 		switch {
 		case strings.HasSuffix(fileName, "fga.mod"):
 			*format = ModelFormatModular
@@ -53,7 +53,7 @@ func ReadFromFile(
 		default:
 			*format = ModelFormatFGA
 		}
-	case *format == ModelFormatModular:
+	case ModelFormatModular:
 		// If we're provided a modular model we want the input to be the filename as we will handle
 		// reading and parsing the fga.mod file later
 		*input = fileName

--- a/internal/authorizationmodel/read-from-input.go
+++ b/internal/authorizationmodel/read-from-input.go
@@ -42,7 +42,7 @@ func ReadFromFile(
 	*input = string(file)
 
 	// if the input format is set as the default, set it from the file extension (and default to fga)
-	// nolint:staticcheck,exhaustive
+	//nolint:staticcheck,exhaustive
 	if *format == ModelFormatDefault {
 		switch {
 		case strings.HasSuffix(fileName, "fga.mod"):

--- a/internal/authorizationmodel/read-from-input.go
+++ b/internal/authorizationmodel/read-from-input.go
@@ -42,7 +42,8 @@ func ReadFromFile(
 	*input = string(file)
 
 	// if the input format is set as the default, set it from the file extension (and default to fga)
-	if *format == ModelFormatDefault {
+	switch {
+	case *format == ModelFormatDefault:
 		switch {
 		case strings.HasSuffix(fileName, "fga.mod"):
 			*format = ModelFormatModular
@@ -52,7 +53,7 @@ func ReadFromFile(
 		default:
 			*format = ModelFormatFGA
 		}
-	} else if *format == ModelFormatModular {
+	case *format == ModelFormatModular:
 		// If we're provided a modular model we want the input to be the filename as we will handle
 		// reading and parsing the fga.mod file later
 		*input = fileName

--- a/internal/storetest/storedata.go
+++ b/internal/storetest/storedata.go
@@ -130,7 +130,7 @@ func (storeData *StoreData) LoadTuples(basePath string) error {
 	}
 
 	if errs != nil {
-		return errors.Join(errors.New("failed to process one or more tuple files"), errs) //nolint:goerr113
+		return errors.Join(errors.New("failed to process one or more tuple files"), errs) //nolint:err113
 	}
 
 	return nil

--- a/internal/tuple/import.go
+++ b/internal/tuple/import.go
@@ -43,23 +43,23 @@ func validateImportParams(minRPS, maxRPS, rampUpPeriodInSec, maxTuplesPerWrite, 
 ) error {
 	if maxRPS != 0 && minRPS > maxRPS {
 		if minRPS <= 0 || maxRPS <= 0 || rampUpPeriodInSec < 0 {
-			return errors.New("ramp-up parameters must be a positive integer") //nolint:goerr113
+			return errors.New("ramp-up parameters must be a positive integer") //nolint:err113
 		}
 
-		return errors.New("minRPS must be less than or equal to maxRPS") //nolint:goerr113
+		return errors.New("minRPS must be less than or equal to maxRPS") //nolint:err113
 	}
 
 	if maxTuplesPerWrite < 1 {
-		return errors.New("maxTuplesPerWrite must be at least 1") //nolint:goerr113
+		return errors.New("maxTuplesPerWrite must be at least 1") //nolint:err113
 	}
 
 	if maxParallelRequests < 1 {
-		return errors.New("maxParallelRequests must be at least 1") //nolint:goerr113
+		return errors.New("maxParallelRequests must be at least 1") //nolint:err113
 	}
 
 	requestsLen := len(body.Writes) + len(body.Deletes)
 	if requestsLen > math.MaxInt32 {
-		return fmt.Errorf( //nolint:goerr113
+		return fmt.Errorf( //nolint:err113
 			"too many requests in ramp up: %d. max supported is %d", requestsLen, math.MaxInt32,
 		)
 	}

--- a/internal/tuplefile/csv.go
+++ b/internal/tuplefile/csv.go
@@ -114,7 +114,7 @@ func (columns *csvColumns) setHeaderIndex(headerName string, index int) error {
 	case "condition_context":
 		columns.ConditionContext = index
 	default:
-		return fmt.Errorf("invalid header %q, valid headers are user_type,user_id,user_relation,relation,object_type,object_id,condition_name,condition_context", headerName) //nolint:goerr113,lll
+		return fmt.Errorf("invalid header %q, valid headers are user_type,user_id,user_relation,relation,object_type,object_id,condition_name,condition_context", headerName) //nolint:err113,lll
 	}
 
 	return nil
@@ -142,7 +142,7 @@ func (columns *csvColumns) validate() error {
 	}
 
 	if columns.ConditionContext != -1 && columns.ConditionName == -1 {
-		return errors.New( //nolint:goerr113
+		return errors.New( //nolint:err113
 			"missing \"condition_name\" header which is required when \"condition_context\" is present",
 		)
 	}

--- a/internal/tuplefile/read.go
+++ b/internal/tuplefile/read.go
@@ -23,7 +23,7 @@ func ReadTupleFile(fileName string) ([]client.ClientTupleKey, error) {
 	case ".csv":
 		err = parseTuplesFromCSV(data, &tuples)
 	default:
-		err = fmt.Errorf("unsupported file format %q", path.Ext(fileName)) //nolint:goerr113
+		err = fmt.Errorf("unsupported file format %q", path.Ext(fileName)) //nolint:err113
 	}
 
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR migrates the project to golangci-lint v2 to support golangci/golangci-lint-action v7.

Changes:
- Added version field to .golangci.yaml
- Updated linter configuration syntax
- Updated nolint directives to use new linter names

The migration was done following the official migration guide: https://golangci-lint.run/product/migration-guide/

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Fixes https://github.com/openfga/cli/pull/474#issuecomment-2768769262

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

