### PR TITLE
fix: validate command to exit with non-zero status on errors

### DIFF
--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -124,7 +124,7 @@ var validateCmd = &cobra.Command{
 
 		// Return a validation error if the model is invalid
 		if !response.IsValid {
-			return clierrors.ValidationError("validate", *response.Error) //nolint:wrapcheck
+			return clierrors.ValidationError("validate", *response.Error)
 		}
 
 		return nil

--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -116,7 +117,23 @@ var validateCmd = &cobra.Command{
 
 		response := validate(authModel)
 
-		return output.Display(response)
+		// Check if model is invalid BEFORE displaying the output
+		var validationErr error
+		if !response.IsValid {
+			validationErr = fmt.Errorf("model validation failed: %s", *response.Error)
+		}
+
+		// Display the results regardless of validation success/failure
+		if displayErr := output.Display(response); displayErr != nil {
+			return displayErr //nolint:wrapcheck
+		}
+
+		// Return the validation error if one occurred
+		if validationErr != nil {
+			return validationErr
+		}
+
+		return nil
 	},
 }
 

--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -117,12 +117,12 @@ var validateCmd = &cobra.Command{
 
 		response := validate(authModel)
 
-		// Display the results regardless of validation success/failure
-		if displayErr := output.Display(response); displayErr != nil {
-			return displayErr //nolint:wrapcheck
+		err = output.Display(response)
+		if err != nil {
+			return err //nolint:wrapcheck
 		}
 
-		// Return a validation error if the model is invalid
+		// Return an error if validation failed to ensure non-zero exit code
 		if !response.IsValid {
 			return clierrors.ValidationError("validate", *response.Error)
 		}

--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -18,7 +18,6 @@ package model
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -29,6 +28,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/openfga/cli/internal/authorizationmodel"
+	"github.com/openfga/cli/internal/clierrors"
 	"github.com/openfga/cli/internal/output"
 )
 
@@ -117,20 +117,14 @@ var validateCmd = &cobra.Command{
 
 		response := validate(authModel)
 
-		// Check if model is invalid BEFORE displaying the output
-		var validationErr error
-		if !response.IsValid {
-			validationErr = fmt.Errorf("model validation failed: %s", *response.Error)
-		}
-
 		// Display the results regardless of validation success/failure
 		if displayErr := output.Display(response); displayErr != nil {
 			return displayErr //nolint:wrapcheck
 		}
 
-		// Return the validation error if one occurred
-		if validationErr != nil {
-			return validationErr
+		// Return a validation error if the model is invalid
+		if !response.IsValid {
+			return clierrors.ValidationError("validate", *response.Error) //nolint:wrapcheck
 		}
 
 		return nil

--- a/internal/authorizationmodel/model.go
+++ b/internal/authorizationmodel/model.go
@@ -284,27 +284,6 @@ func (model *AuthzModel) ReadModelFromString(input string, format ModelFormat) e
 	return nil
 }
 
-func (model *AuthzModel) setCreatedAt() {
-	if *model.ID != "" {
-		modelID, err := ulid.Parse(*model.ID)
-		if err == nil {
-			createdAt := ulid.Time(modelID.Time()).UTC()
-			model.CreatedAt = &createdAt
-		}
-	}
-}
-
-func (model *AuthzModel) GetAsJSONString() (*string, error) {
-	bytes, err := json.Marshal(model)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal due to %w", err)
-	}
-
-	jsonString := string(bytes)
-
-	return &jsonString, nil
-}
-
 func (model *AuthzModel) DisplayAsJSON(fields []string) AuthzModel {
 	newModel := AuthzModel{}
 
@@ -374,4 +353,25 @@ func (model *AuthzModel) DisplayAsDSL(fields []string) (*string, error) {
 	}
 
 	return &dslModel, nil
+}
+
+func (model *AuthzModel) GetAsJSONString() (*string, error) {
+	bytes, err := json.Marshal(model)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal due to %w", err)
+	}
+
+	jsonString := string(bytes)
+
+	return &jsonString, nil
+}
+
+func (model *AuthzModel) setCreatedAt() {
+	if *model.ID != "" {
+		modelID, err := ulid.Parse(*model.ID)
+		if err == nil {
+			createdAt := ulid.Time(modelID.Time()).UTC()
+			model.CreatedAt = &createdAt
+		}
+	}
 }

--- a/internal/fga/fga.go
+++ b/internal/fga/fga.go
@@ -47,6 +47,15 @@ type ClientConfig struct {
 	Debug                bool     `json:"debug,omitempty"`
 }
 
+func (c ClientConfig) GetFgaClient() (*client.OpenFgaClient, error) {
+	fgaClient, err := client.NewSdkClient(c.getClientConfig())
+	if err != nil {
+		return nil, err //nolint:wrapcheck
+	}
+
+	return fgaClient, nil
+}
+
 func (c ClientConfig) getCredentials() *credentials.Credentials {
 	if c.APIToken != "" {
 		return &credentials.Credentials{
@@ -88,13 +97,4 @@ func (c ClientConfig) getClientConfig() *client.ClientConfiguration {
 		},
 		Debug: c.Debug,
 	}
-}
-
-func (c ClientConfig) GetFgaClient() (*client.OpenFgaClient, error) {
-	fgaClient, err := client.NewSdkClient(c.getClientConfig())
-	if err != nil {
-		return nil, err //nolint:wrapcheck
-	}
-
-	return fgaClient, nil
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR fixes the `fga model validate` command to properly exit with a non-zero status code when validation fails, making it more useful in CI/CD pipelines and build tools like Bazel.

Also fixed some linting issues related to function ordering in the codebase.



## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

fixes #484

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected