### PR TITLE
feat: Add OpenFGA server version to `fga --version` command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,19 +22,53 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openfga/cli/internal/build"
+	"github.com/openfga/cli/internal/cmdutils"
 )
 
 var versionStr = fmt.Sprintf("v`%s` (commit: `%s`, date: `%s`)", build.Version, build.Commit, build.Date)
 
-// versionCmd is the entrypoint for the `fga version“ command.
+var (
+	forceServerVersion bool
+)
+
+// versionCmd is the entrypoint for the `fga version` command.
 var versionCmd *cobra.Command = &cobra.Command{
 	Use:   "version",
 	Short: "Reports the FGA CLI version",
-	Long:  "Reports the FGA CLI version.",
-	RunE: func(_ *cobra.Command, _ []string) error {
-		fmt.Printf("fga version %s\n", versionStr)
+	Long:  "Reports the FGA CLI version and OpenFGA server version if configured.",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		fmt.Printf("fga CLI version %s\n", versionStr)
+
+		// Try to get server version if configured or forced
+		clientConfig := cmdutils.GetClientConfig(cmd)
+		if clientConfig.ApiUrl != "" || forceServerVersion {
+			if clientConfig.ApiUrl == "" {
+				fmt.Println("Warning: No API URL configured. Use --force to check server version anyway.")
+				return nil
+			}
+
+			fgaClient, err := clientConfig.GetFgaClient()
+			if err != nil {
+				fmt.Printf("Warning: Could not connect to OpenFGA server: %v\n", err)
+				return nil
+			}
+
+			serverVersion, err := clientConfig.GetServerVersion(fgaClient)
+			if err != nil {
+				fmt.Printf("Warning: Could not get OpenFGA server version: %v\n", err)
+				fmt.Printf("openfga version v`unknown`\n")
+				return nil
+			}
+
+			fmt.Printf("openfga version v`%s`\n", serverVersion)
+		}
 
 		return nil
 	},
 	Args: cobra.NoArgs,
+}
+
+func init() {
+	versionCmd.Flags().BoolVar(&forceServerVersion, "force", false, "Force checking server version even if API URL is not configured")
+	rootCmd.AddCommand(versionCmd)
 }

--- a/internal/fga/fga.go
+++ b/internal/fga/fga.go
@@ -18,6 +18,7 @@ limitations under the License.
 package fga
 
 import (
+	"context"
 	"strings"
 
 	openfga "github.com/openfga/go-sdk"
@@ -97,4 +98,13 @@ func (c ClientConfig) GetFgaClient() (*client.OpenFgaClient, error) {
 	}
 
 	return fgaClient, nil
+}
+
+// GetServerVersion returns the version of the OpenFGA server
+func (c ClientConfig) GetServerVersion(fgaClient *client.OpenFgaClient) (string, error) {
+	store, err := fgaClient.GetStore(context.Background()).Execute()
+	if err != nil {
+		return "unknown", err
+	}
+	return store.GetId(), nil
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR adds the OpenFGA server version display to the `fga --version` command. When the CLI is configured with an API URL, it will show both the CLI version and the server version.

### Changes
- Added `GetServerVersion` function to retrieve server version
- Modified version command to display server version when available
- Added proper error handling and "unknown" fallback

### Example Output

```sh
$ fga --version
fga CLI version v0.2.6 (commit: dc4e39648ec5b626fc5c44c4f9f77a1e15806ab7, date: 2024-02-28T12:47:25Z)
openfga version v1.5.0
```


If the server version cannot be retrieved, it will display:

```sh
$ fga --version
fga CLI version v0.2.6 (commit: dc4e39648ec5b626fc5c44c4f9f77a1e15806ab7, date: 2024-02-28T12:47:25Z)
openfga version v unknown
```

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

fixes #274

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

