### PR TITLE
feat: support multiple tuple files

### DIFF
--- a/internal/storetest/storedata.go
+++ b/internal/storetest/storedata.go
@@ -65,12 +65,13 @@ type ModelTest struct {
 }
 
 type StoreData struct {
-	Name      string                            `json:"name"       yaml:"name"`
-	Model     string                            `json:"model"      yaml:"model"`
-	ModelFile string                            `json:"model_file" yaml:"model_file,omitempty"` //nolint:tagliatelle
-	Tuples    []client.ClientContextualTupleKey `json:"tuples"     yaml:"tuples"`
-	TupleFile string                            `json:"tuple_file" yaml:"tuple_file,omitempty"` //nolint:tagliatelle
-	Tests     []ModelTest                       `json:"tests"      yaml:"tests"`
+	Name       string                            `json:"name"       yaml:"name"`
+	Model      string                            `json:"model"      yaml:"model"`
+	ModelFile  string                            `json:"model_file" yaml:"model_file,omitempty"` //nolint:tagliatelle
+	Tuples     []client.ClientContextualTupleKey `json:"tuples"     yaml:"tuples"`
+	TupleFile  string                            `json:"tuple_file" yaml:"tuple_file,omitempty"` //nolint:tagliatelle
+	TupleFiles []string                          `json:"tuple_files" yaml:"tuple_files,omitempty"`
+	Tests      []ModelTest                       `json:"tests"      yaml:"tests"`
 }
 
 func (storeData *StoreData) LoadModel(basePath string) (authorizationmodel.ModelFormat, error) {
@@ -112,6 +113,24 @@ func (storeData *StoreData) LoadTuples(basePath string) error {
 			storeData.Tuples = tuples
 		} else {
 			storeData.Tuples = append(storeData.Tuples, tuples...)
+		}
+	}
+
+	if storeData.TupleFiles != nil {
+		for _, tupleFile := range storeData.TupleFiles {
+			tuples, err := tuplefile.ReadTupleFile(path.Join(basePath, tupleFile))
+			if err != nil {
+				errs = errors.Join(
+					errs,
+					fmt.Errorf("failed to process tuple file %s due to %w", tupleFile, err),
+				)
+				continue
+			}
+			if storeData.Tuples == nil {
+				storeData.Tuples = tuples
+			} else {
+				storeData.Tuples = append(storeData.Tuples, tuples...)
+			}
 		}
 	}
 


### PR DESCRIPTION
I was giving this feature a shot,
I was able to make it work when you provide the source test files like such
```
name: Test Store
model_file: ./test.fga
#tuple_file: ./singletuple.yaml
tuple_files:
  - ./tuple.yaml
  - ./tuple_2.yaml
tests:
  - name:  Admin checks
    description: To test what   authorisation on all objects
    check:
    ```
    
   Although this is still in draft mode so let me know if this is what we expect, I can finish the tests then

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

