### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Changelog
 
-#### [Unreleased](https://github.com/openfga/cli/compare/v0.6.6...HEAD)
+#### [Unreleased](https://github.com/openfga/cli/compare/v0.7.0...HEAD)
+
+#### [0.7.0](https://github.com/openfga/cli/compare/v0.6.6...v0.7.0) (2025-06-10)
+
+> [!NOTE]
+> This release includes a change to the configuration file (`.fga.yaml`) lookup order to simplify multi-project usage.
+> The lookup is now in the following order:
+> * Current working directory (New)
+> * OS-specific [user configuration directory](https://pkg.go.dev/os#UserConfigDir) (e.g. `~/.config`)
+> * `fga` directory within the OS-specific [user configuration directory](https://pkg.go.dev/os#UserConfigDir) (e.g. `~/.config/fga`)
+> * OS-specific [home directory](https://pkg.go.dev/os#UserHomeDir) (e.g. `~/`)
+
+Added:
+- Include current working directory in the config file resolution (#504) - thanks @OsmanMElsayed
 
 Fixed:
 - Bump OpenFGA to v1.8.13 to resolve a security vulnerability [GHSA-c72g-53hw-82q7](https://github.com/openfga/openfga/security/advisories/GHSA-c72g-53hw-82q7)
-
 
 #### [0.6.6](https://github.com/openfga/cli/compare/v0.6.5...v0.6.6) (2025-04-23)
 


### PR DESCRIPTION
## Description

Cuts a v0.7.0 release with the following, the specific changes to the config file lookup in #504 are called out as they seemed noteworthy. 

```
Added:
- Include current working directory in the config file resolution (#504) - thanks @OsmanMElsayed

Fixed:
- Bump OpenFGA to v1.8.13 to resolve a security vulnerability [GHSA-c72g-53hw-82q7](https://github.com/openfga/openfga/security/advisories/GHSA-c72g-53hw-82q7)
```

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

