### PR TITLE
Improve tuple write logging

### DIFF
--- a/internal/tuple/import_test.go
+++ b/internal/tuple/import_test.go
@@ -1,6 +1,7 @@
 package tuple
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestProcessWrites(t *testing.T) {
 		},
 	}
 
-	successful, failed := processWrites(writes)
+	successful, failed := processWrites(context.Background(), writes)
 
 	assert.Len(t, successful, 1)
 	assert.Len(t, failed, 1)
@@ -45,7 +46,7 @@ func TestProcessDeletes(t *testing.T) {
 		},
 	}
 
-	successful, failed := processDeletes(deletes)
+	successful, failed := processDeletes(context.Background(), deletes)
 
 	assert.Len(t, successful, 1)
 	assert.Len(t, failed, 1)

--- a/internal/utils/context.go
+++ b/internal/utils/context.go
@@ -1,6 +1,9 @@
 package utils
 
-import "context"
+import (
+	"context"
+	"os"
+)
 
 type contextKey struct {
 	name string
@@ -16,4 +19,31 @@ func GetDebugContextValue(ctx context.Context) bool {
 	debug, _ := ctx.Value(keyDebug).(bool)
 
 	return debug
+}
+
+var (
+	keySuccessLog = contextKey{"successLog"}
+	keyFailureLog = contextKey{"failureLog"}
+)
+
+// WithSuccessLog attaches a success log file to the context.
+func WithSuccessLog(ctx context.Context, file *os.File) context.Context {
+	return context.WithValue(ctx, keySuccessLog, file)
+}
+
+// WithFailureLog attaches a failure log file to the context.
+func WithFailureLog(ctx context.Context, file *os.File) context.Context {
+	return context.WithValue(ctx, keyFailureLog, file)
+}
+
+// GetSuccessLog retrieves the success log file from the context.
+func GetSuccessLog(ctx context.Context) *os.File {
+	file, _ := ctx.Value(keySuccessLog).(*os.File)
+	return file
+}
+
+// GetFailureLog retrieves the failure log file from the context.
+func GetFailureLog(ctx context.Context) *os.File {
+	file, _ := ctx.Value(keyFailureLog).(*os.File)
+	return file
 }


### PR DESCRIPTION
## Summary
- add success/failure file writers to context
- update ImportTuples to stream results to the log files
- wire new flags into `tuple write`
- log progress using slog

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ea0184cd08322b70f8d3f29e848aa