### PR TITLE
Add logging flags for tuple writes

### DIFF
--- a/cmd/tuple/tuple.go
+++ b/cmd/tuple/tuple.go
@@ -38,6 +38,8 @@ func init() {
 	TupleCmd.AddCommand(deleteCmd)
 
 	TupleCmd.PersistentFlags().String("store-id", "", "Store ID")
+	TupleCmd.PersistentFlags().String("success-log", "", "Filepath to log successful writes")
+	TupleCmd.PersistentFlags().String("failure-log", "", "Filepath to log failed writes")
 
 	err := TupleCmd.MarkPersistentFlagRequired("store-id")
 	if err != nil { //nolint:wsl

--- a/internal/tuple/import_test.go
+++ b/internal/tuple/import_test.go
@@ -1,6 +1,7 @@
 package tuple
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestProcessWrites(t *testing.T) {
 		},
 	}
 
-	successful, failed := processWrites(writes)
+	successful, failed := processWrites(context.Background(), writes)
 
 	assert.Len(t, successful, 1)
 	assert.Len(t, failed, 1)
@@ -45,7 +46,7 @@ func TestProcessDeletes(t *testing.T) {
 		},
 	}
 
-	successful, failed := processDeletes(deletes)
+	successful, failed := processDeletes(context.Background(), deletes)
 
 	assert.Len(t, successful, 1)
 	assert.Len(t, failed, 1)

--- a/internal/tuple/logger.go
+++ b/internal/tuple/logger.go
@@ -1,0 +1,137 @@
+package tuple
+
+import (
+	"bufio"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openfga/go-sdk/client"
+	"gopkg.in/yaml.v3"
+)
+
+// TupleLogger writes tuple logs in various formats.
+type TupleLogger struct {
+	file          *os.File
+	writer        *bufio.Writer
+	format        string
+	headerWritten bool
+	isFailure     bool
+}
+
+// NewTupleLogger creates a logger for the given file path.
+func NewTupleLogger(path string, isFailure bool) (*TupleLogger, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log file %s: %w", path, err)
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("failed to stat log file %s: %w", path, err)
+	}
+
+	return &TupleLogger{
+		file:          f,
+		writer:        bufio.NewWriter(f),
+		format:        strings.ToLower(filepath.Ext(path)),
+		headerWritten: info.Size() > 0,
+		isFailure:     isFailure,
+	}, nil
+}
+
+func (l *TupleLogger) Close() error {
+	if l == nil {
+		return nil
+	}
+	_ = l.writer.Flush()
+	_ = l.file.Sync()
+	return l.file.Close()
+}
+
+func (l *TupleLogger) flush() {
+	_ = l.writer.Flush()
+	_ = l.file.Sync()
+}
+
+// LogSuccess writes a successful tuple key.
+func (l *TupleLogger) LogSuccess(key client.ClientTupleKey) {
+	if l == nil {
+		return
+	}
+	switch l.format {
+	case ".csv":
+		l.writeCSV([]string{key.User, key.Relation, key.Object})
+	case ".yaml", ".yml":
+		b, _ := yaml.Marshal(key)
+		l.writer.Write(b)
+		l.writer.Write([]byte("---\n"))
+	default: // json and jsonl
+		b, _ := json.Marshal(key)
+		l.writer.Write(append(b, '\n'))
+	}
+	l.flush()
+}
+
+// LogFailure writes a failed tuple with reason.
+func (l *TupleLogger) LogFailure(failed failedWriteResponse) {
+	if l == nil {
+		return
+	}
+	switch l.format {
+	case ".csv":
+		l.writeCSV([]string{failed.TupleKey.User, failed.TupleKey.Relation, failed.TupleKey.Object, failed.Reason})
+	case ".yaml", ".yml":
+		b, _ := yaml.Marshal(failed)
+		l.writer.Write(b)
+		l.writer.Write([]byte("---\n"))
+	default:
+		b, _ := json.Marshal(failed)
+		l.writer.Write(append(b, '\n'))
+	}
+	l.flush()
+}
+
+func (l *TupleLogger) writeCSV(record []string) {
+	w := csv.NewWriter(l.writer)
+	if !l.headerWritten {
+		if l.isFailure {
+			w.Write([]string{"user", "relation", "object", "reason"})
+		} else {
+			w.Write([]string{"user", "relation", "object"})
+		}
+		l.headerWritten = true
+	}
+	_ = w.Write(record)
+	w.Flush()
+}
+
+// Context utilities
+
+type logKey struct{ name string }
+
+var successLogKey = &logKey{"successLog"}
+var failureLogKey = &logKey{"failureLog"}
+
+func WithSuccessLogger(ctx context.Context, l *TupleLogger) context.Context {
+	return context.WithValue(ctx, successLogKey, l)
+}
+
+func WithFailureLogger(ctx context.Context, l *TupleLogger) context.Context {
+	return context.WithValue(ctx, failureLogKey, l)
+}
+
+func getSuccessLogger(ctx context.Context) *TupleLogger {
+	logger, _ := ctx.Value(successLogKey).(*TupleLogger)
+	return logger
+}
+
+func getFailureLogger(ctx context.Context) *TupleLogger {
+	logger, _ := ctx.Value(failureLogKey).(*TupleLogger)
+	return logger
+}


### PR DESCRIPTION
## Summary
- add persistent success-log and failure-log flags
- support success/failure logging in tuple import
- flush logs after each tuple operation
- allow suppressing stdout when logs are enabled

## Testing
- `make test-unit`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_686c2ec5a4b48322adc0e1ba7263f18e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for logging successful and failed tuple writes and deletions to separate log files using new command-line flags.
  * Log files can be generated in CSV, YAML, or JSON formats based on file extension.
  * CLI output now suppresses display of successful or failed tuples if corresponding log files are specified.

* **Documentation**
  * Added descriptions for new flags to help users utilize the logging feature.

* **Tests**
  * Updated tests to support new logging functionality and context usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->