### PR TITLE
Add glob support for test command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Fixed:
 - Bump OpenFGA to v1.8.13 to resolve a security vulnerability [GHSA-c72g-53hw-82q7](https://github.com/openfga/openfga/security/advisories/GHSA-c72g-53hw-82q7)
 
+Added:
+- Support running `fga model test` with multiple files using glob patterns (#423)
+
 
 #### [0.6.6](https://github.com/openfga/cli/compare/v0.6.5...v0.6.6) (2025-04-23)
 

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ fga store **delete**
 | [Write Authorization Model ](#write-authorization-model)                    | `write`     | `--store-id`, `--file`     | `fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 --file model.fga`                    |
 | [Read a Single Authorization Model](#read-a-single-authorization-model)     | `get`       | `--store-id`, `--model-id` | `fga model get --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1` |
 | [Validate an Authorization Model](#validate-an-authorization-model)         | `validate`  | `--file`, `--format`       | `fga model validate --file model.fga`                                                       |
-| [Run Tests on an Authorization Model](#run-tests-on-an-authorization-model) | `test`      | `--tests`, `--verbose`     | `fga model test --tests tests.fga.yaml`                                                     |
+| [Run Tests on an Authorization Model](#run-tests-on-an-authorization-model) | `test`      | `--tests`, `--verbose`     | `fga model test --tests \"tests/*.fga.yaml\"`                                                     |
 | [Transform an Authorization Model](#transform-an-authorization-model)       | `transform` | `--file`, `--input-format` | `fga model transform --file model.json`                                                     |
 
 
@@ -525,7 +525,7 @@ fga model **test**
 
 ###### Parameters
 
-* `--tests`: Name of the tests file. Must be in yaml format (see below)
+* `--tests`: Name of the tests file, or a glob pattern to multiple files (for example `tests/*.fga.yaml`). Each file must be in yaml format (see below)
 * `--verbose`: Outputs the results in JSON
 
 If a model is provided, the test will run in a built-in OpenFGA instance (you do not need a separate server). Otherwise, the test will be run against the configured store of your OpenFGA instance. When running against a remote instance, the tuples will be sent as contextual tuples, and will have to abide by the OpenFGA server limits (20 contextual tuples per request).
@@ -604,7 +604,7 @@ tests: # required
 ```
 
 ###### Example
-`fga model test --tests tests.fga.yaml`
+`fga model test --tests "tests/*.fga.yaml"`
 
 For more examples of `.fga.yaml` files, check the [sample-stores repository](https://github.com/openfga/sample-stores/)/
 

--- a/cmd/model/model.go
+++ b/cmd/model/model.go
@@ -34,6 +34,6 @@ func init() {
 	ModelCmd.AddCommand(getCmd)
 	ModelCmd.AddCommand(validateCmd)
 	ModelCmd.AddCommand(transformCmd)
-	ModelCmd.AddCommand(testCmd)
-	ModelCmd.PersistentFlags().String("store-id", "", "Store ID")
+        ModelCmd.AddCommand(modelTestCmd)
+        ModelCmd.PersistentFlags().String("store-id", "", "Store ID")
 }

--- a/cmd/model/test_test.go
+++ b/cmd/model/test_test.go
@@ -1,0 +1,166 @@
+package model
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     modelTestCmd.Use,
+		Short:   modelTestCmd.Short,
+		Long:    modelTestCmd.Long,
+		Example: modelTestCmd.Example,
+		RunE:    modelTestCmd.RunE,
+	}
+	c.Flags().String("tests", "", "path or glob of YAML/JSON test files")
+	c.Flags().String("api-url", "http://localhost:8080", "api url")
+	c.Flags().Bool("verbose", false, "Print verbose JSON output")
+	c.Flags().Bool("suppress-summary", false, "Suppress the plain text summary output")
+	_ = c.MarkFlagRequired("tests")
+	return c
+}
+
+func writeTestFile(t *testing.T, dir, name, expect string) string {
+	t.Helper()
+	content := `name: Sample
+model: |
+  model
+    schema 1.1
+
+  type user
+  type doc
+    relations
+      define viewer: [user]
+tuples:
+  - user: user:anne
+    relation: viewer
+    object: doc:1
+tests:
+  - name: check
+    check:
+      - user: user:anne
+        object: doc:1
+        assertions:
+          viewer: ` + expect + "\n"
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	return path
+}
+
+type executeResult struct {
+	out     string
+	err     string
+	execErr error
+}
+
+func executeCmd(t *testing.T, cmd *cobra.Command, args ...string) executeResult {
+	t.Helper()
+	bufOut := &bytes.Buffer{}
+	bufErr := &bytes.Buffer{}
+	cmd.SetOut(bufOut)
+	cmd.SetErr(bufErr)
+	cmd.SetArgs(args)
+	execErr := cmd.Execute()
+	return executeResult{bufOut.String(), bufErr.String(), execErr}
+}
+
+func TestModelTestCmdMissingFlag(t *testing.T) {
+	cmd := newTestCmd()
+	res := executeCmd(t, cmd)
+	if res.execErr == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestModelTestCmdInvalidGlob(t *testing.T) {
+	cmd := newTestCmd()
+	res := executeCmd(t, cmd, "--tests", "[")
+	if res.execErr == nil {
+		t.Fatalf("expected error for invalid glob")
+	}
+}
+
+func TestModelTestCmdZeroMatches(t *testing.T) {
+	cmd := newTestCmd()
+	res := executeCmd(t, cmd, "--tests", "no-such-file-*.yaml")
+	if res.execErr == nil {
+		t.Fatalf("expected error for missing file")
+	}
+}
+
+func TestModelTestCmdSingleFilePass(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "ok.fga.yaml", "true")
+	cmd := newTestCmd()
+	res := executeCmd(t, cmd, "--tests", file)
+	if res.execErr != nil {
+		t.Fatalf("unexpected error: %v", res.execErr)
+	}
+	if res.err == "" {
+		t.Fatalf("expected summary on stderr")
+	}
+}
+
+func TestModelTestCmdSingleFileFail(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "fail.fga.yaml", "false")
+	cmd := newTestCmd()
+	res := executeCmd(t, cmd, "--tests", file)
+	if res.execErr == nil {
+		t.Fatalf("expected failure error")
+	}
+}
+
+func TestModelTestCmdMultiFile(t *testing.T) {
+	dir := t.TempDir()
+	_ = writeTestFile(t, dir, "a.fga.yaml", "true")
+	_ = writeTestFile(t, dir, "b.fga.yaml", "true")
+	pattern := filepath.Join(dir, "*.fga.yaml")
+	cmd := newTestCmd()
+	res := executeCmd(t, cmd, "--tests", pattern)
+	if res.execErr != nil {
+		t.Fatalf("unexpected error: %v", res.execErr)
+	}
+	if count := strings.Count(res.err, "# "); count != 3 { // two files + summary
+		t.Fatalf("expected per-file and summary output, got %q", res.err)
+	}
+}
+
+func TestModelTestCmdVerboseSuppress(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "ok.fga.yaml", "true")
+	cmd := newTestCmd()
+	res := executeCmd(t, cmd, "--tests", file, "--verbose", "--suppress-summary")
+	if res.execErr != nil {
+		t.Fatalf("unexpected error: %v", res.execErr)
+	}
+	if strings.Contains(res.err, "# Test Summary") {
+		t.Fatalf("summary should be suppressed")
+	}
+}
+
+func TestModelTestCmdContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "ok.fga.yaml", "true")
+	cmd := newTestCmd()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	bufOut := &bytes.Buffer{}
+	bufErr := &bytes.Buffer{}
+	cmd.SetOut(bufOut)
+	cmd.SetErr(bufErr)
+	cmd.SetArgs([]string{"--tests", file})
+	err := cmd.ExecuteContext(ctx)
+	if err == nil {
+		t.Fatalf("expected cancellation error")
+	}
+}

--- a/internal/cmdutils/get-logger.go
+++ b/internal/cmdutils/get-logger.go
@@ -1,0 +1,28 @@
+/*
+Copyright © 2023 OpenFGA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdutils
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+// GetLogger returns a logger writing to the command's stderr.
+func GetLogger(cmd *cobra.Command) *log.Logger {
+	return log.New(cmd.ErrOrStderr(), "", 0)
+}

--- a/internal/storetest/testresult.go
+++ b/internal/storetest/testresult.go
@@ -350,6 +350,13 @@ func (test TestResults) FriendlyDisplay() string { //nolint:cyclop
 	return summary
 }
 
+// FriendlyBody returns only the summary body without the leading header.
+func (test TestResults) FriendlyBody() string {
+	const header = "# Test Summary #\n"
+	out := test.FriendlyDisplay()
+	return strings.TrimPrefix(out, header)
+}
+
 func buildTestSummary(failedTestCount int, summary string, totalTestCount int,
 	totalCheckCount int, failedCheckCount int,
 	totalListObjectsCount int, failedListObjectsCount int,

--- a/internal/storetest/tests.go
+++ b/internal/storetest/tests.go
@@ -1,6 +1,8 @@
 package storetest
 
 import (
+	"context"
+
 	"github.com/openfga/go-sdk/client"
 	"github.com/openfga/openfga/pkg/server"
 
@@ -14,12 +16,16 @@ type ModelTestOptions struct {
 }
 
 func RunTest(
+	ctx context.Context,
 	fgaClient *client.OpenFgaClient,
 	fgaServer *server.Server,
 	test ModelTest,
 	globalTuples []client.ClientContextualTupleKey,
 	model *authorizationmodel.AuthzModel,
 ) (TestResult, error) {
+	if ctx.Err() != nil {
+		return TestResult{}, ctx.Err()
+	}
 	testTuples := append(append([]client.ClientContextualTupleKey{}, globalTuples...), test.Tuples...)
 
 	if model == nil {
@@ -30,6 +36,7 @@ func RunTest(
 }
 
 func RunTests(
+	ctx context.Context,
 	fgaClient *client.OpenFgaClient,
 	storeData *StoreData,
 	format authorizationmodel.ModelFormat,
@@ -44,7 +51,12 @@ func RunTests(
 	defer stopServerFn()
 
 	for _, test := range storeData.Tests {
+		if ctx.Err() != nil {
+			return testResults, ctx.Err()
+		}
+
 		result, err := RunTest(
+			ctx,
 			fgaClient,
 			fgaServer,
 			test,


### PR DESCRIPTION
## Summary
- allow providing glob patterns to `model test`
- document new test globbing capability
- document this change in CHANGELOG
- show per-file headers with filenames when running multiple files
- display full file path in per-file test summaries
- don't prefix summary with file name when testing a single file
- refactor model test command with concurrency, context, and logging

## Testing
- `go vet ./...`
- `go test ./...`
- `make test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684859e0ba448322b5cf1c04ccc5aa1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running model tests with multiple files using glob patterns in the CLI.
  * Introduced concurrent execution of multiple test files for improved performance.
  * Enhanced logging with consistent output to the error stream.

* **Bug Fixes**
  * Improved error handling and messaging for invalid or missing test files.

* **Documentation**
  * Updated documentation to clarify support for glob patterns in test file selection and improved usage examples.

* **Tests**
  * Added comprehensive tests covering single and multiple file scenarios, error conditions, and context cancellation.

* **Refactor**
  * Improved CLI flag handling and removed unused flags for clarity.
  * Introduced context-aware cancellation in test execution functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->