### PR TITLE
fix: store tuples being required

### DIFF
--- a/internal/storetest/storedata.go
+++ b/internal/storetest/storedata.go
@@ -38,7 +38,6 @@ var (
 	ErrObjectAndObjectsConflict = errors.New("cannot contain both 'object' and 'objects'")
 	ErrObjectRequired           = errors.New("must specify 'object' or 'objects'")
 
-	errMissingTuple               = errors.New("either tuple_file or tuple_files or tuples must be provided")
 	errFailedProcessingTupleFiles = errors.New("failed to process one or more tuple files")
 )
 
@@ -131,22 +130,19 @@ func (storeData *StoreData) LoadTuples(basePath string) error {
 		addTuples(storeData.Tuples)
 	}
 
-	if storeData.TupleFile == "" && len(storeData.TupleFiles) == 0 && len(allTuples) == 0 {
+	if storeData.TupleFile != "" {
 		errs = errors.Join(
 			errs,
-			errMissingTuple,
+			storeData.loadAndAddTuplesFromFile(basePath, storeData.TupleFile, addTuples),
 		)
 	}
 
-	errs = errors.Join(
-		errs,
-		storeData.loadAndAddTuplesFromFile(basePath, storeData.TupleFile, addTuples),
-	)
-
-	errs = errors.Join(
-		errs,
-		storeData.loadAndAddTuplesFromFiles(basePath, storeData.TupleFiles, addTuples),
-	)
+	if len(storeData.TupleFiles) > 0 {
+		errs = errors.Join(
+			errs,
+			storeData.loadAndAddTuplesFromFiles(basePath, storeData.TupleFiles, addTuples),
+		)
+	}
 
 	if len(allTuples) > 0 {
 		storeData.Tuples = allTuples

--- a/internal/storetest/storedata_test.go
+++ b/internal/storetest/storedata_test.go
@@ -45,9 +45,9 @@ func TestLoadTuples(t *testing.T) {
 		expectTuples int
 	}{
 		{
-			name:      "no tuple file or tuple files",
-			storeData: StoreData{},
-			expectErr: true,
+			name:         "no tuple file or tuple files",
+			storeData:    StoreData{},
+			expectTuples: 0,
 		},
 		{
 			name: "single tuple_file",


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This change allows users to:
* Run tests with only tuples defined in tests
* Run tests with only global tuples
* Run specific tests as if no tuples exist
* Run tests with tuples in the tests and globally


#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

closes https://github.com/openfga/cli/issues/539

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when no tuple files are provided; the system now loads zero tuples without reporting an error.

* **Tests**
  * Updated test cases to expect zero tuples loaded (instead of an error) when no tuple files are specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->