### PR TITLE
feat: support wildcards in model paths

### DIFF
--- a/internal/authorizationmodel/model_test.go
+++ b/internal/authorizationmodel/model_test.go
@@ -246,7 +246,14 @@ contents: []
 
 func writeModuleFragment(t *testing.T, dir, name, content string) {
 	t.Helper()
-	fullPath := filepath.Join(dir, name+".fga")
+	tempDir := dir
+	if dir == "" {
+		var err error
+		tempDir, err = os.MkdirTemp("", "fga_test")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(tempDir) })
+	}
+	fullPath := filepath.Join(tempDir, name+".fga")
 	fragment := "model\n  schema 1.2\n\n" + strings.TrimSpace(content) + "\n"
 	require.NoError(t, os.WriteFile(fullPath, []byte(fragment), 0644))
 }


### PR DESCRIPTION
Solves _
#538 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using wildcard (glob) patterns when specifying module files in the authorization model configuration, allowing for more flexible file inclusion.
* **Bug Fixes**
  * Improved error reporting for cases where wildcard patterns do not match any files or file loading fails.
* **Tests**
  * Introduced comprehensive tests to verify correct handling of wildcard patterns and error scenarios in model loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->