### PR TITLE
feat: Add configurable page-size parameter to `fga tuple read` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+Added:
+- Add configurable `--page-size` parameter to `fga tuple read` command with intelligent defaults ([#571](https://github.com/openfga/cli/pull/571))
+  * When `--max-pages=0` (read all tuples), defaults to 100 for better efficiency
+  * When `--max-pages!=0` (limited pages), defaults to 50 to maintain backward compatibility
+  * Custom page size can be specified with `--page-size` flag
+
 ## [0.7.4] - 2025-08-15
 
 Changed:

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ store-id: 01H0H015178Y2V4CX10C2KGHF4
 fga store **create**
 
 ###### Parameters
-* `--name`: Name of the store to be created. If the `model` parameter is specified, the model file name will be used as the default store name. 
+* `--name`: Name of the store to be created. If the `model` parameter is specified, the model file name will be used as the default store name.
 * `--model`: File with the authorization model. Can be in JSON, OpenFGA format, or fga.mod file (optional).
 * `--format` : Authorization model input format. Can be "fga", "json", or "modular" (optional, defaults to the model file extension if present).
 
@@ -394,11 +394,11 @@ fga store **delete**
 | [Write Authorization Model ](#write-authorization-model)                    | `write`     | `--store-id`, `--file`     | `fga model write --store-id=01H0H015178Y2V4CX10C2KGHF4 --file model.fga`                    |
 | [Read a Single Authorization Model](#read-a-single-authorization-model)     | `get`       | `--store-id`, `--model-id` | `fga model get --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1` |
 | [Validate an Authorization Model](#validate-an-authorization-model)         | `validate`  | `--file`, `--format`       | `fga model validate --file model.fga`                                                       |
-| [Run Tests on an Authorization Model](#run-tests-on-an-authorization-model) | `test`      | `--tests`, `--verbose`     | `fga model test --tests "**/*.fga.yaml"`                                                     | 
+| [Run Tests on an Authorization Model](#run-tests-on-an-authorization-model) | `test`      | `--tests`, `--verbose`     | `fga model test --tests "**/*.fga.yaml"`                                                     |
 | [Transform an Authorization Model](#transform-an-authorization-model)       | `transform` | `--file`, `--input-format` | `fga model transform --file model.json`                                                     |
 
 
-##### Read Authorization Models 
+##### Read Authorization Models
 
 List all authorization models for a store, in descending order by creation date. The first model in the list is the latest one.
 
@@ -429,7 +429,7 @@ fga model **list**
 }
 ```
 
-##### Write Authorization Model 
+##### Write Authorization Model
 
 ###### Command
 fga model **write**
@@ -451,7 +451,7 @@ fga model **write**
 }
 ```
 
-##### Read a Single Authorization Model 
+##### Read a Single Authorization Model
 
 ###### Command
 fga model **get**
@@ -477,7 +477,7 @@ type document
     define can_view: [user]
 ```
 
-##### Read the Latest Authorization Model 
+##### Read the Latest Authorization Model
 
 If `model-id` is not specified when using the `get` command, the latest authorization model will be returned.
 
@@ -559,7 +559,7 @@ model: |
   type user
   type folder
     relations
-      define owner: [user] 
+      define owner: [user]
       define parent: [folder]
       define can_view: owner or can_view from parent
       define can_write: owner or can_write from parent
@@ -663,7 +663,7 @@ ListObjects 3/3 passing
 The **transform** command lets you convert between different authorization model formats (`.fga`, `.json`, `.mod`).
 
 ###### Command
-fga model **transform** 
+fga model **transform**
 
 ###### Parameters
 * `--file`: File containing the authorization model
@@ -910,7 +910,8 @@ fga tuple **read** [--user=<user>] [--relation=<relation>] [--object=<object>]  
 * `--user`: User
 * `--relation`: Relation
 * `--object`: Object
-* `--max-pages`: Max number of pages to get. (default 20)
+* `--max-pages`: Max number of pages to get. Set to 0 to get all pages. (default 20)
+* `--page-size`: Number of tuples to return per page. Defaults to 100 when max-pages=0, or 50 otherwise. Max is 100.
 * `--output-format`: Can be `csv`, `yaml`, `json` or `simple-json`. Use `simple-json` for a simpler json format that can be piped to the write and delete commands
 
 ###### Example

--- a/cmd/store/export.go
+++ b/cmd/store/export.go
@@ -68,7 +68,7 @@ func buildStoreData(ctx context.Context, config fga.ClientConfig, fgaClient clie
 	// get the tuples
 	maxPages := int(math.Ceil(float64(maxTupleCount) / float64(tuple.DefaultReadPageSize)))
 
-	rawTuples, err := tuple.Read(ctx, fgaClient, &client.ClientReadRequest{}, maxPages, nil)
+	rawTuples, err := tuple.Read(ctx, fgaClient, &client.ClientReadRequest{}, maxPages, tuple.DefaultReadPageSize, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read tuples: %w", err)
 	}

--- a/cmd/tuple/read.go
+++ b/cmd/tuple/read.go
@@ -96,6 +96,7 @@ func read(
 	relation string,
 	object string,
 	maxPages int,
+	pageSize int32,
 	consistency *openfga.ConsistencyPreference,
 ) (
 	*readResponse, error,
@@ -113,7 +114,7 @@ func read(
 		body.Object = &object
 	}
 
-	response, err := tuple.Read(ctx, fgaClient, body, maxPages, consistency)
+	response, err := tuple.Read(ctx, fgaClient, body, maxPages, pageSize, consistency)
 	if err != nil {
 		return nil, err //nolint:wrapcheck
 	}
@@ -151,12 +152,27 @@ var readCmd = &cobra.Command{
 			return fmt.Errorf("failed to parse max pages due to %w", err)
 		}
 
+		pageSize, _ := cmd.Flags().GetInt32("page-size")
+
+		// Apply the new page-size logic based on max-pages
+		if pageSize == 0 {
+			// No page-size specified, apply default logic
+			if maxPages == 0 {
+				// When max-pages=0, default page-size should be 100
+				pageSize = 100
+			} else {
+				// When max-pages!=0, default page-size should be 50
+				pageSize = 50
+			}
+		}
+		// If page-size is specified (non-zero), use whatever is specified
+
 		consistency, err := cmdutils.ParseConsistencyFromCmd(cmd)
 		if err != nil {
 			return fmt.Errorf("error parsing consistency for check: %w", err)
 		}
 
-		response, err := read(cmd.Context(), fgaClient, user, relation, object, maxPages, consistency)
+		response, err := read(cmd.Context(), fgaClient, user, relation, object, maxPages, pageSize, consistency)
 		if err != nil {
 			return err
 		}
@@ -191,6 +207,7 @@ func init() {
 	readCmd.Flags().String("relation", "", "Relation")
 	readCmd.Flags().String("object", "", "Object")
 	readCmd.Flags().Int("max-pages", MaxReadPagesLength, "Max number of pages to get. Set to 0 to get all pages.")
+	readCmd.Flags().Int32("page-size", 0, "Number of tuples to return per page. Defaults to 100 when max-pages=0, or 50 otherwise. Max is 100.")
 	readCmd.Flags().String("output-format", "json", "Specifies the format for data presentation. Valid options: "+
 		"json, simple-json, csv, and yaml.")
 	readCmd.Flags().Bool("simple-output", false, "Output data in simpler version. (It can be used by write and delete commands)") //nolint:lll

--- a/cmd/tuple/read.go
+++ b/cmd/tuple/read.go
@@ -154,6 +154,14 @@ var readCmd = &cobra.Command{
 
 		pageSize, _ := cmd.Flags().GetInt32("page-size")
 
+		// Validate page-size if explicitly provided
+		if pageSize < 0 {
+			return fmt.Errorf("page-size must be non-negative, got %d", pageSize)
+		}
+		if pageSize > 100 {
+			return fmt.Errorf("page-size cannot exceed 100, got %d", pageSize)
+		}
+
 		// Apply the new page-size logic based on max-pages
 		if pageSize == 0 {
 			// No page-size specified, apply default logic

--- a/cmd/tuple/read.go
+++ b/cmd/tuple/read.go
@@ -19,6 +19,7 @@ package tuple
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -33,6 +34,13 @@ import (
 
 // MaxReadPagesLength Limit the tuples so that we are not paginating indefinitely.
 var MaxReadPagesLength = 20
+
+var (
+	// ErrPageSizeNegative is returned when page size is negative.
+	ErrPageSizeNegative = errors.New("page-size must be non-negative")
+	// ErrPageSizeExceedsMax is returned when page size exceeds maximum.
+	ErrPageSizeExceedsMax = errors.New("page-size cannot exceed 100")
+)
 
 type readResponse struct {
 	complete *openfga.ReadResponse
@@ -156,10 +164,10 @@ var readCmd = &cobra.Command{
 
 		// Validate page-size if explicitly provided
 		if pageSize < 0 {
-			return fmt.Errorf("page-size must be non-negative, got %d", pageSize)
+			return fmt.Errorf("%w: got %d", ErrPageSizeNegative, pageSize)
 		}
 		if pageSize > 100 {
-			return fmt.Errorf("page-size cannot exceed 100, got %d", pageSize)
+			return fmt.Errorf("%w: got %d", ErrPageSizeExceedsMax, pageSize)
 		}
 
 		// Apply the new page-size logic based on max-pages

--- a/cmd/tuple/read.go
+++ b/cmd/tuple/read.go
@@ -177,8 +177,8 @@ var readCmd = &cobra.Command{
 				// When max-pages=0, default page-size should be 100
 				pageSize = 100
 			} else {
-				// When max-pages!=0, default page-size should be 50
-				pageSize = 50
+				// When max-pages!=0, use the default page size
+				pageSize = tuple.DefaultReadPageSize
 			}
 		}
 		// If page-size is specified (non-zero), use whatever is specified

--- a/cmd/tuple/read.go
+++ b/cmd/tuple/read.go
@@ -207,7 +207,8 @@ func init() {
 	readCmd.Flags().String("relation", "", "Relation")
 	readCmd.Flags().String("object", "", "Object")
 	readCmd.Flags().Int("max-pages", MaxReadPagesLength, "Max number of pages to get. Set to 0 to get all pages.")
-	readCmd.Flags().Int32("page-size", 0, "Number of tuples to return per page. Defaults to 100 when max-pages=0, or 50 otherwise. Max is 100.")
+	readCmd.Flags().Int32("page-size", 0, "Number of tuples to return per page. "+
+		"Defaults to 100 when max-pages=0, or 50 otherwise. Max is 100.")
 	readCmd.Flags().String("output-format", "json", "Specifies the format for data presentation. Valid options: "+
 		"json, simple-json, csv, and yaml.")
 	readCmd.Flags().Bool("simple-output", false, "Output data in simpler version. (It can be used by write and delete commands)") //nolint:lll

--- a/cmd/tuple/read_test.go
+++ b/cmd/tuple/read_test.go
@@ -676,7 +676,8 @@ func TestReadWithInvalidPageSize(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for page size > 100, but got none")
 	}
-	if err != nil && err.Error() != "pageSize must be between 1 and 100, got 101" {
+
+	if err != nil && err.Error() != "pageSize must be between 1 and 100: got 101" {
 		t.Errorf("Expected specific error message, got: %v", err)
 	}
 
@@ -694,7 +695,8 @@ func TestReadWithInvalidPageSize(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for page size < 1, but got none")
 	}
-	if err != nil && err.Error() != "pageSize must be between 1 and 100, got 0" {
+
+	if err != nil && err.Error() != "pageSize must be between 1 and 100: got 0" {
 		t.Errorf("Expected specific error message, got: %v", err)
 	}
 }

--- a/cmd/tuple/read_test.go
+++ b/cmd/tuple/read_test.go
@@ -591,8 +591,8 @@ func TestReadWithPageSize50WhenMaxPagesIsNonZero(t *testing.T) {
 		"user:user1",
 		"reader",
 		"document:doc1",
-		5,                            // max-pages = 5 (non-zero)
-		tuple.DefaultReadPageSize,    // expected page size
+		5,                          // max-pages = 5 (non-zero)
+		tuple.DefaultReadPageSize, // expected page size
 		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
 	)
 	if err != nil {

--- a/cmd/tuple/read_test.go
+++ b/cmd/tuple/read_test.go
@@ -653,3 +653,48 @@ func TestReadWithCustomPageSize(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestReadWithInvalidPageSize(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockFgaClient := mock_client.NewMockSdkClient(mockCtrl)
+
+	// Test page size > 100
+	_, err := read(
+		t.Context(),
+		mockFgaClient,
+		"user:user1",
+		"reader",
+		"document:doc1",
+		0,
+		101, // invalid page size > 100
+		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
+	)
+	if err == nil {
+		t.Error("Expected error for page size > 100, but got none")
+	}
+	if err != nil && err.Error() != "pageSize must be between 1 and 100, got 101" {
+		t.Errorf("Expected specific error message, got: %v", err)
+	}
+
+	// Test page size < 1
+	_, err = read(
+		t.Context(),
+		mockFgaClient,
+		"user:user1",
+		"reader",
+		"document:doc1",
+		0,
+		0, // invalid page size < 1
+		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
+	)
+	if err == nil {
+		t.Error("Expected error for page size < 1, but got none")
+	}
+	if err != nil && err.Error() != "pageSize must be between 1 and 100, got 0" {
+		t.Errorf("Expected specific error message, got: %v", err)
+	}
+}

--- a/cmd/tuple/read_test.go
+++ b/cmd/tuple/read_test.go
@@ -491,7 +491,7 @@ func toPointer[T any](p T) *T {
 	return &p
 }
 
-// Test page size behavior based on max-pages parameter
+// Test page size behavior based on max-pages parameter.
 func TestReadWithPageSize100WhenMaxPagesIsZero(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/tuple/read_test.go
+++ b/cmd/tuple/read_test.go
@@ -566,9 +566,9 @@ func TestReadWithPageSize50WhenMaxPagesIsNonZero(t *testing.T) {
 	mockExecute.EXPECT().Execute().Return(&response, nil)
 
 	mockRequest := mock_client.NewMockSdkClientReadRequestInterface(mockCtrl)
-	// Expect page size to be 50 when max-pages is non-zero
+	// Expect page size to be DefaultReadPageSize when max-pages is non-zero
 	options := client.ClientReadOptions{
-		PageSize:          openfga.PtrInt32(50),
+		PageSize:          openfga.PtrInt32(tuple.DefaultReadPageSize),
 		ContinuationToken: openfga.PtrString(""),
 	}
 	mockRequest.EXPECT().Options(options).Return(mockExecute)
@@ -584,15 +584,15 @@ func TestReadWithPageSize50WhenMaxPagesIsNonZero(t *testing.T) {
 
 	mockFgaClient.EXPECT().Read(t.Context()).Return(mockBody)
 
-	// When max-pages is non-zero, page size should be 50
+	// When max-pages is non-zero, page size should be DefaultReadPageSize
 	_, err := read(
 		t.Context(),
 		mockFgaClient,
 		"user:user1",
 		"reader",
 		"document:doc1",
-		5,  // max-pages = 5 (non-zero)
-		50, // expected page size
+		5,                            // max-pages = 5 (non-zero)
+		tuple.DefaultReadPageSize,    // expected page size
 		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
 	)
 	if err != nil {

--- a/cmd/tuple/read_test.go
+++ b/cmd/tuple/read_test.go
@@ -591,7 +591,7 @@ func TestReadWithPageSize50WhenMaxPagesIsNonZero(t *testing.T) {
 		"user:user1",
 		"reader",
 		"document:doc1",
-		5,                          // max-pages = 5 (non-zero)
+		5,                         // max-pages = 5 (non-zero)
 		tuple.DefaultReadPageSize, // expected page size
 		openfga.CONSISTENCYPREFERENCE_UNSPECIFIED.Ptr(),
 	)

--- a/internal/tuple/read.go
+++ b/internal/tuple/read.go
@@ -11,10 +11,8 @@ import (
 
 const DefaultReadPageSize int32 = 50
 
-var (
-	// ErrInvalidPageSize is returned when page size is outside valid range.
-	ErrInvalidPageSize = errors.New("pageSize must be between 1 and 100")
-)
+// ErrInvalidPageSize is returned when page size is outside valid range.
+var ErrInvalidPageSize = errors.New("pageSize must be between 1 and 100")
 
 func Read(
 	ctx context.Context,

--- a/internal/tuple/read.go
+++ b/internal/tuple/read.go
@@ -2,6 +2,7 @@ package tuple
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	openfga "github.com/openfga/go-sdk"
@@ -9,6 +10,11 @@ import (
 )
 
 const DefaultReadPageSize int32 = 50
+
+var (
+	// ErrInvalidPageSize is returned when page size is outside valid range.
+	ErrInvalidPageSize = errors.New("pageSize must be between 1 and 100")
+)
 
 func Read(
 	ctx context.Context,
@@ -21,7 +27,7 @@ func Read(
 	*openfga.ReadResponse, error,
 ) {
 	if pageSize < 1 || pageSize > 100 {
-		return nil, fmt.Errorf("pageSize must be between 1 and 100, got %d", pageSize)
+		return nil, fmt.Errorf("%w: got %d", ErrInvalidPageSize, pageSize)
 	}
 
 	tuples := make([]openfga.Tuple, 0)

--- a/internal/tuple/read.go
+++ b/internal/tuple/read.go
@@ -20,6 +20,10 @@ func Read(
 ) (
 	*openfga.ReadResponse, error,
 ) {
+	if pageSize < 1 || pageSize > 100 {
+		return nil, fmt.Errorf("pageSize must be between 1 and 100, got %d", pageSize)
+	}
+
 	tuples := make([]openfga.Tuple, 0)
 	continuationToken := ""
 	pageIndex := 0

--- a/internal/tuple/read.go
+++ b/internal/tuple/read.go
@@ -15,6 +15,7 @@ func Read(
 	fgaClient client.SdkClient,
 	body *client.ClientReadRequest,
 	maxPages int,
+	pageSize int32,
 	consistency *openfga.ConsistencyPreference,
 ) (
 	*openfga.ReadResponse, error,
@@ -23,7 +24,7 @@ func Read(
 	continuationToken := ""
 	pageIndex := 0
 	options := client.ClientReadOptions{
-		PageSize: openfga.PtrInt32(DefaultReadPageSize),
+		PageSize: openfga.PtrInt32(pageSize),
 	}
 
 	if consistency != nil && *consistency != openfga.CONSISTENCYPREFERENCE_UNSPECIFIED {


### PR DESCRIPTION
## Description

This PR enhances the `fga tuple read` command by adding support for a configurable `page-size` parameter and implementing intelligent default page-size behavior based on the `max-pages` setting to improve performance when reading tuples.

## Related Issue

Fixes #568

## Changes made

- Added `--page-size` flag to the `fga tuple read` command
- Implemented smart default page-size logic:
  - When `max-pages=0` (read all tuples): defaults to 100 for better efficiency
  - When `max-pages!=0` (limited pages): defaults to 50 to maintain backward compatibility
  - When `--page-size` is explicitly specified: uses the provided value
- Updated internal `tuple.Read` function to accept page size as a parameter
- Updated `cmd/store/export.go` to use the appropriate page size
- Added comprehensive unit tests for the new page-size behavior

## Command usage examples

### 1. Read all tuples (optimized with page-size=100)

**Command:**
```bash
fga tuple read --store-id=01H0H015178Y2V4CX10C2KGHF4 --max-pages=0
```

**Output:**
```json
{
  "tuples": [
    {
      "key": {
        "user": "user:anne",
        "relation": "reader",
        "object": "document:roadmap"
      },
      "timestamp": "2024-01-15T10:30:00Z"
    },
    {
      "key": {
        "user": "user:bob",
        "relation": "writer",
        "object": "document:design"
      },
      "timestamp": "2024-01-15T10:31:00Z"
    }
    // ... fetches up to 100 tuples per page instead of 50
  ],
  "continuation_token": ""
}
```

### 2. Read with limited pages (default page-size=50)

**Command:**
```bash
fga tuple read --store-id=01H0H015178Y2V4CX10C2KGHF4 --max-pages=2 --user user:anne
```

**Output:**
```json
{
  "tuples": [
    {
      "key": {
        "user": "user:anne",
        "relation": "reader",
        "object": "document:roadmap"
      },
      "timestamp": "2024-01-15T10:30:00Z"
    },
    {
      "key": {
        "user": "user:anne",
        "relation": "viewer",
        "object": "folder:projects"
      },
      "timestamp": "2024-01-15T10:32:00Z"
    }
    // ... up to 50 tuples per page (maintains backward compatibility)
  ],
  "continuation_token": ""
}
```

### 3. Read with custom page size

**Command:**
```bash
fga tuple read --store-id=01H0H015178Y2V4CX10C2KGHF4 --max-pages=3 --page-size=75 --relation viewer
```

**Output:**
```json
{
  "tuples": [
    {
      "key": {
        "user": "user:anne",
        "relation": "viewer",
        "object": "folder:projects"
      },
      "timestamp": "2024-01-15T10:32:00Z"
    },
    {
      "key": {
        "user": "user:bob",
        "relation": "viewer",
        "object": "folder:shared"
      },
      "timestamp": "2024-01-15T10:33:00Z"
    }
    // ... fetches up to 75 tuples per page as specified
  ],
  "continuation_token": "eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTUUoyN01MdTdqTjh0Ym42MjA4In0="
}
```

### 4. Help output showing new flag

**Command:**
```bash
fga tuple read --help
```

**Output (relevant section):**
```
Flags:
  -h, --help                 help for read
      --max-pages int        Max number of pages to get. Set to 0 to get all pages. (default 20)
      --object string        Object
      --output-format string Specifies the format for data presentation. Valid options: json, simple-json, csv, and yaml. (default "json")
      --page-size int32      Number of tuples to return per page. Defaults to 100 when max-pages=0, or 50 otherwise. Max is 100.
      --relation string      Relation
      --user string          User
      --consistency string   Consistency preference for the request. Valid options are HIGHER_CONSISTENCY and MINIMIZE_LATENCY.
```

## Performance Impact

For stores with many tuples, this change significantly reduces API calls when reading all tuples:

| Scenario | Before (page-size=50) | After (page-size=100) | Improvement |
|----------|------------------------|------------------------|-------------|
| 100 tuples | 2 API calls | 1 API call | 50% reduction |
| 500 tuples | 10 API calls | 5 API calls | 50% reduction |
| 1000 tuples | 20 API calls | 10 API calls | 50% reduction |
| 5000 tuples | 100 API calls | 50 API calls | 50% reduction |

## No breaking changes

This PR does not include breaking changes.

The default behavior when `max-pages!=0` remains unchanged (page-size=50), ensuring complete backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a --page-size flag to the tuple read command, allowing users to control how many results are returned per page.
  * Introduced smart defaults when --page-size is not provided: 100 when no max page limit is set, and 50 when a max page limit is specified.
  * Improves pagination control and performance predictability when reading large sets of tuples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->