### PR TITLE
release: v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.5] - 2025-10-09
+
 Added:
-- Add configurable `--page-size` parameter to `fga tuple read` command with intelligent defaults ([#571](https://github.com/openfga/cli/pull/571))
+- Add configurable `--page-size` parameter to `fga tuple read` command with intelligent defaults ([#571](https://github.com/openfga/cli/pull/571)) - thanks @Siddhant-K-code
   * When `--max-pages=0` (read all tuples), defaults to 100 for better efficiency
   * When `--max-pages!=0` (limited pages), defaults to 50 to maintain backward compatibility
   * Custom page size can be specified with `--page-size` flag
 
 Changed:
 - Import now ignores duplicate tuples instead of failing the import. Note: this feature requires OpenFGA server [v1.10.0](https://github.com/openfga/openfga/releases/tag/v1.10.0) or later. You can still import to previous versions, but this setting will be ignored. Writes that are not imports (aka. writing a single tuple instead of from a file) will still fail on duplicates.
+
+Fixed:
+- Issue retrying 5xx errors. Fixed upstream (https://github.com/openfga/go-sdk/issues/204)
 
 ## [0.7.4] - 2025-08-15
 
@@ -328,7 +333,8 @@ Initial OpenFGA CLI release
   * List relations a user has on an object
   * Use Expand to understand why access was granted
 
-[Unreleased]: https://github.com/openfga/cli/compare/v0.7.4...HEAD
+[Unreleased]: https://github.com/openfga/cli/compare/v0.7.5...HEAD
+[0.7.5]: https://github.com/openfga/cli/compare/v0.7.4...v0.7.5
 [0.7.4]: https://github.com/openfga/cli/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/openfga/cli/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/openfga/cli/compare/v0.7.1...v0.7.2


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Changes
---
Added:
- Add configurable `--page-size` parameter to `fga tuple read` command with intelligent defaults ([#571](https://github.com/openfga/cli/pull/571))
  * When `--max-pages=0` (read all tuples), defaults to 100 for better efficiency
  * When `--max-pages!=0` (limited pages), defaults to 50 to maintain backward compatibility
  * Custom page size can be specified with `--page-size` flag
Changed:
- Import now ignores duplicate tuples instead of failing the import. Note: this feature requires OpenFGA server [v1.10.0](https://github.com/openfga/openfga/releases/tag/v1.10.0) or later. You can still import to previous versions, but this setting will be ignored. Writes that are not imports (aka. writing a single tuple instead of from a file) will still fail on duplicates.

Fixed:
- Issue retrying 5xx errors. Fixed upstream (https://github.com/openfga/go-sdk/issues/204)

#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable --page-size for fga tuple read with improved defaults and ability to override.

* **Changed**
  * Import now ignores duplicate tuples during import (requires OpenFGA v1.10.0+); older servers may behave differently. Non-import writes unchanged regarding duplicates.

* **Documentation**
  * Added Unreleased section for version 0.7.5 (2025-10-08) outlining the new page-size option and import behavior updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->