### PR TITLE
release: v0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.8] - 2025-11-05
+
+Fixed:
+- Fix path resolution in `fga model test` to no longer resolve paths using the files base path
+
 ## [0.7.7] - 2025-11-04
 
 > [!NOTE]
@@ -351,6 +356,7 @@ Initial OpenFGA CLI release
   * Use Expand to understand why access was granted
 
 [Unreleased]: https://github.com/openfga/cli/compare/v0.7.7...HEAD
+[0.7.8]: https://github.com/openfga/cli/compare/v0.7.7...v0.7.8
 [0.7.7]: https://github.com/openfga/cli/compare/v0.7.5...v0.7.7
 [0.7.5]: https://github.com/openfga/cli/compare/v0.7.4...v0.7.5
 [0.7.4]: https://github.com/openfga/cli/compare/v0.7.3...v0.7.4


### PR DESCRIPTION
## Description

```
## [0.7.8] - 2025-11-05

Fixed:
- Fix path resolution in `fga model test` to no longer resolve paths using the files base path
```


## References


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with version 0.7.8 release notes, documenting a fix for path resolution handling in FGA model tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->