### PR TITLE
fix: show warning when config is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+Fixed:
+- CLI now warns users when `.fga.yaml` config file has YAML parsing errors instead of silently ignoring them. Use `--debug` flag or set `FGA_DEBUG=true` for detailed error messages
+
 ## [0.7.8] - 2025-11-05
 
 Fixed:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

```sh
$ ./dist/fga --config ./bla.yaml --debug=true version 
Warning: Failed to load config file ./bla.yaml: While parsing config: yaml: line 3: found unexpected end of stream
```

```sh
$ ./dist/fga --config ./bla.yaml --debug=false version 
Warning: Failed to load config file. Use --debug=true or set FGA_DEBUG=true for details.
```

| Scenario                                    | Behavior                                                  |
|---------------------------------------------|-----------------------------------------------------------|
| Config file not found (auto-discovery)      | ✅ Silent - continues normally                             |
| Config file found with valid YAML           | ✅ Shows "Using config file: /path/to/.fga.yaml"           |
| Config file found with invalid YAML         | ⚠️ Shows minimal warning                                  |
| Invalid YAML + --debug=true flag            | ⚠️ Shows detailed warning with file path and error        |
| Invalid YAML + FGA_DEBUG=true env var       | ⚠️ Shows detailed warning with file path and error        |
| Explicit --config with missing/invalid file | ⚠️ Shows warning |

Note: these will only warn and the actual command will continue

#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

closes #608 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now warns users when YAML configuration files fail to parse, instead of silently ignoring parsing errors.
  * Detailed error information is available through debug mode using the --debug flag or FGA_DEBUG=true environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->