### PR TITLE
docs: clarify local-vs-server behavior for model test

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,9 @@ fga model **test**
 * `--verbose`: Outputs the results in JSON
 * `--max-types-per-authorization-model`: Max allowed number of type definitions per authorization model (default: 100). Increase this when testing models with more than 100 type definitions.
 
-If a model is provided, the test will run in a built-in OpenFGA instance (you do not need a separate server). Otherwise, the test will be run against the configured store of your OpenFGA instance. When running against a remote instance, the tuples will be sent as contextual tuples, and will have to abide by the OpenFGA server limits (20 contextual tuples per request).
+If a model is provided (for example, in a `.fga.yaml` tests file), the tests run locally in a built-in OpenFGA instance (you do not need a separate server).
+
+If no model is provided, the tests run against the configured OpenFGA server and store (for example via `--store-id` or your config/env values). When running against a remote instance, tuples are sent as contextual tuples and must abide by the OpenFGA server limits (20 contextual tuples per request).
 
 The tests file should be in yaml and have the following format:
 

--- a/cmd/model/test.go
+++ b/cmd/model/test.go
@@ -165,8 +165,8 @@ var modelTestCmd = &cobra.Command{
 }
 
 func init() {
-	modelTestCmd.Flags().String("store-id", "", "Store ID")
-	modelTestCmd.Flags().String("model-id", "", "Model ID")
+	modelTestCmd.Flags().String("store-id", "", "Store ID (used when tests do not define a model)")
+	modelTestCmd.Flags().String("model-id", "", "Model ID (used when tests do not define a model)")
 	modelTestCmd.Flags().String("tests", "", "Path or glob of YAML test files")
 	modelTestCmd.Flags().Bool("verbose", false, "Print verbose JSON output")
 	modelTestCmd.Flags().Bool("suppress-summary", false, "Suppress the plain text summary output")

--- a/docs/STORE_FILE.md
+++ b/docs/STORE_FILE.md
@@ -290,6 +290,8 @@ Run tests against an authorization model:
 fga model test --tests store.fga.yaml
 ```
 
+If the `.fga.yaml` file includes a `model` or `model_file`, `fga model test` runs locally against a built-in OpenFGA instance. If the file does not define a model, tests run against the configured OpenFGA server/store.
+
 ### Store Export
 Export store configuration to file:
 ```bash


### PR DESCRIPTION
## Summary\n- clarify that \ runs locally when the tests file defines a model (\ or \)\n- clarify that remote store/model flags apply when no model is defined in the tests file\n- align README, store file docs, and CLI flag descriptions\n\nFixes #335\n\n## Validation\n- go test ./cmd/model/...