### PR TITLE
feat: report serialized model size in fga model get and validate

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -43,6 +43,7 @@ linters:
             - github.com/spf13/viper
             - golang.org/x/time/rate
             - google.golang.org/protobuf/encoding/protojson
+            - google.golang.org/protobuf/proto
             - google.golang.org/protobuf/types/known/structpb
             - gopkg.in/yaml.v3
         test:
@@ -59,6 +60,7 @@ linters:
             - go.uber.org/mock/gomock
             - github.com/spf13/cobra
             - github.com/spf13/viper
+            - google.golang.org/protobuf/proto
     funlen:
       lines: 120
       statements: 80

--- a/README.md
+++ b/README.md
@@ -491,13 +491,16 @@ fga model **get**
 * `--store-id`: Specifies the store id
 * `--model-id`: Specifies the model id
 * `--format`: Authorization model output format. Can be "fga" or "json" (default fga).
-* `--field`: Fields to display, choices are: `id`, `created_at` and `model`. Default is `model`.
+* `--field`: Fields to display, choices are: `id`, `created_at`, `size` and `model`. Default is `model`.
 
 ###### Example
-`fga model get --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1`
+`fga model get --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1 --field size --field model --field id --field created_at`
 
 ###### Response
 ```python
+# Model ID: 01GXSA8YR785C4FYS3C0RTG7B1
+# Created At: 2023-04-11 23:26:34.759 +0000 UTC
+# Size: 20.05 KB
 model
   schema 1.1
 
@@ -506,6 +509,20 @@ type user
 type document
   relations
     define can_view: [user]
+```
+
+In `json` format, the fields appear intermixed with the model.
+
+`fga model get --store-id=01H0H015178Y2V4CX10C2KGHF4 --model-id=01GXSA8YR785C4FYS3C0RTG7B1 --field size --field model --field id --field created_at --format=json`
+
+```json
+{
+  "id":"01GXSA8YR785C4FYS3C0RTG7B1",
+  "created_at":"2023-04-11T23:26:34.759Z",
+  "size_kb":20.05,
+  "schema_version":"1.1",
+  "type_definitions": [...]
+}
 ```
 
 ##### Read the Latest Authorization Model
@@ -545,22 +562,24 @@ fga model **validate**
 ###### Example
 `fga model validate --file model.json`
 
+When the input parses successfully, the JSON response includes `size_kb`, the protobuf-serialized size of the model in KB. If the input cannot be parsed, the command exits with an error and does not emit a JSON response.
+
 ###### JSON Response
 * Valid model with an ID
 ```json5
-{"id":"01GPGWB8R33HWXS3KK6YG4ETGH","created_at":"2023-01-11T16:59:22Z","is_valid":true}
+{"id":"01GPGWB8R33HWXS3KK6YG4ETGH","created_at":"2023-01-11T16:59:22Z","is_valid":true,"size_kb":0.05}
 ```
 * Valid model without an ID
 ```json5
-{"is_valid":true}
+{"is_valid":true,"size_kb":0.05}
 ```
 * Invalid model with an ID
 ```json5
-{"id":"01GPGTVEH5NYTQ19RYFQKE0Q4Z","created_at":"2023-01-11T16:33:15Z","is_valid":false,"error":"invalid schema version"}
+{"id":"01GPGTVEH5NYTQ19RYFQKE0Q4Z","created_at":"2023-01-11T16:33:15Z","is_valid":false,"error":"invalid schema version","size_kb":0.05}
 ```
 * Invalid model without an ID
 ```json5
-{"is_valid":false,"error":"the relation type 'employee' on 'member' in object type 'group' is not valid"}
+{"is_valid":false,"error":"the relation type 'employee' on 'member' in object type 'group' is not valid","size_kb":0.05}
 ```
 
 ##### Run Tests on an Authorization Model

--- a/cmd/model/get.go
+++ b/cmd/model/get.go
@@ -74,7 +74,7 @@ var getOutputFormat = authorizationmodel.ModelFormatFGA
 func init() {
 	getCmd.Flags().String("model-id", "", "Authorization Model ID")
 	getCmd.Flags().String("store-id", "", "Store ID")
-	getCmd.Flags().StringArray("field", []string{"model"}, "Fields to display, choices are: id, created_at and model") //nolint:lll
+	getCmd.Flags().StringArray("field", []string{"model"}, "Fields to display, choices are: id, created_at, size and model") //nolint:lll
 	getCmd.Flags().Var(&getOutputFormat, "format", `Authorization model output format. Can be "fga" or "json"`)
 
 	if err := getCmd.MarkFlagRequired("store-id"); err != nil {

--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -37,6 +37,7 @@ type validationResult struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	IsValid   bool       `json:"is_valid"`
 	Error     *string    `json:"error,omitempty"`
+	SizeKB    *float64   `json:"size_kb,omitempty"`
 }
 
 func validate(inputModel authorizationmodel.AuthzModel) validationResult {
@@ -54,7 +55,7 @@ func validate(inputModel authorizationmodel.AuthzModel) validationResult {
 		return output
 	}
 
-	err = protojson.Unmarshal([]byte(*modelJSONString), model)
+	err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(*modelJSONString), model)
 	if err != nil {
 		output.IsValid = false
 		errorString := "unable to parse json input"
@@ -62,6 +63,9 @@ func validate(inputModel authorizationmodel.AuthzModel) validationResult {
 
 		return output
 	}
+
+	sizeKB := inputModel.GetSizeInKB()
+	output.SizeKB = &sizeKB
 
 	if model.GetId() != "" {
 		output.ID = model.GetId()

--- a/cmd/model/validate.go
+++ b/cmd/model/validate.go
@@ -64,7 +64,7 @@ func validate(inputModel authorizationmodel.AuthzModel) validationResult {
 		return output
 	}
 
-	sizeKB := inputModel.GetSizeInKB()
+	sizeKB := authorizationmodel.ProtoModelSizeInKB(model)
 	output.SizeKB = &sizeKB
 
 	if model.GetId() != "" {

--- a/cmd/model/validate_test.go
+++ b/cmd/model/validate_test.go
@@ -22,26 +22,21 @@ func TestValidate(t *testing.T) {
 	t.Parallel()
 
 	type validationTest struct {
-		Name           string
-		Input          string
-		IsValid        bool
-		ExpectedOutput validationResult
+		Name             string
+		Input            string
+		ExpectParseError bool
+		ExpectedOutput   validationResult
 	}
 
 	tests := []validationTest{
 		{
-			Name:    "missing schema version",
-			Input:   "{",
-			IsValid: false,
-			ExpectedOutput: validationResult{
-				IsValid: false,
-				Error:   openfga.PtrString("unable to parse json input"),
-			},
+			Name:             "invalid json",
+			Input:            "{",
+			ExpectParseError: true,
 		},
 		{
-			Name:    "missing schema version",
-			Input:   `{"id":"abcde","schema_version":"1.1"}`,
-			IsValid: false,
+			Name:  "invalid model id",
+			Input: `{"id":"abcde","schema_version":"1.1"}`,
 			ExpectedOutput: validationResult{
 				ID:      "abcde",
 				IsValid: false,
@@ -49,27 +44,24 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			Name:    "missing schema version",
-			Input:   "{}",
-			IsValid: false,
+			Name:  "missing schema version",
+			Input: "{}",
 			ExpectedOutput: validationResult{
 				IsValid: false,
 				Error:   openfga.PtrString("invalid schema version"),
 			},
 		},
 		{
-			Name:    "invalid schema version",
-			Input:   `{"schema_version":"1.0"}`,
-			IsValid: false,
+			Name:  "invalid schema version",
+			Input: `{"schema_version":"1.0"}`,
 			ExpectedOutput: validationResult{
 				IsValid: false,
 				Error:   openfga.PtrString("invalid schema version"),
 			},
 		},
 		{
-			Name:    "only schema",
-			Input:   `{"schema_version":"1.1"}`,
-			IsValid: true,
+			Name:  "only schema",
+			Input: `{"schema_version":"1.1"}`,
 			ExpectedOutput: validationResult{
 				IsValid: true,
 			},
@@ -83,8 +75,16 @@ func TestValidate(t *testing.T) {
 			model := authorizationmodel.AuthzModel{}
 
 			err := model.ReadFromJSONString(test.Input)
-			if err != nil {
+			if test.ExpectParseError {
+				if err == nil {
+					t.Fatalf("Expected parse error for input %q, got none", test.Input)
+				}
+
 				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected parse error for input %q: %v", test.Input, err)
 			}
 
 			expected := test.ExpectedOutput

--- a/cmd/model/validate_test.go
+++ b/cmd/model/validate_test.go
@@ -87,11 +87,51 @@ func TestValidate(t *testing.T) {
 				return
 			}
 
+			expected := test.ExpectedOutput
+			size := model.GetSizeInKB()
+			expected.SizeKB = &size
+
 			output := validate(model)
 
-			if !reflect.DeepEqual(output, test.ExpectedOutput) {
-				t.Fatalf("Expect output %v actual %v", test.ExpectedOutput, output)
+			if !reflect.DeepEqual(output, expected) {
+				t.Fatalf("Expect output %v actual %v", expected, output)
 			}
 		})
+	}
+}
+
+func TestValidateReportsSize(t *testing.T) {
+	t.Parallel()
+
+	model := authorizationmodel.AuthzModel{}
+	if err := model.ReadFromJSONString(`{"schema_version":"1.1"}`); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	result := validate(model)
+	if result.SizeKB == nil {
+		t.Fatalf("expected SizeKB to be set")
+	}
+
+	if *result.SizeKB != model.GetSizeInKB() {
+		t.Errorf("expected %v to equal %v", *result.SizeKB, model.GetSizeInKB())
+	}
+}
+
+func TestValidateWithValidIDReportsSize(t *testing.T) {
+	t.Parallel()
+
+	model := authorizationmodel.AuthzModel{}
+	if err := model.ReadFromJSONString(`{"id":"01GVKXGDCV2SMG6TRE9NMBQ2VG","schema_version":"1.1"}`); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	result := validate(model)
+	if !result.IsValid {
+		t.Fatalf("expected valid model, got error: %v", *result.Error)
+	}
+
+	if result.SizeKB == nil {
+		t.Fatalf("expected SizeKB to be set")
 	}
 }

--- a/internal/authorizationmodel/model.go
+++ b/internal/authorizationmodel/model.go
@@ -123,7 +123,12 @@ func (model *AuthzModel) GetProtoModel() *pb.AuthorizationModel {
 }
 
 func (model *AuthzModel) GetSizeInKB() float64 {
-	pbModel := model.GetProtoModel()
+	return ProtoModelSizeInKB(model.GetProtoModel())
+}
+
+// ProtoModelSizeInKB returns the protobuf-serialized size of the model in KB,
+// rounded to two decimal places. Returns 0 for a nil model.
+func ProtoModelSizeInKB(pbModel *pb.AuthorizationModel) float64 {
 	if pbModel == nil {
 		return 0
 	}

--- a/internal/authorizationmodel/model.go
+++ b/internal/authorizationmodel/model.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"time"
@@ -29,6 +30,7 @@ import (
 	openfga "github.com/openfga/go-sdk"
 	language "github.com/openfga/language/pkg/go/transformer"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/openfga/cli/internal/slices"
 )
@@ -51,6 +53,7 @@ type AuthzModelList struct {
 type AuthzModel struct {
 	ID              *string                       `json:"id,omitempty"`
 	CreatedAt       *time.Time                    `json:"created_at,omitempty"`
+	SizeKB          *float64                      `json:"size_kb,omitempty"`
 	SchemaVersion   *string                       `json:"schema_version,omitempty"`
 	TypeDefinitions *[]openfga.TypeDefinition     `json:"type_definitions,omitempty"`
 	Conditions      map[string]*openfga.Condition `json:"conditions,omitempty"`
@@ -112,11 +115,22 @@ func (model *AuthzModel) GetProtoModel() *pb.AuthorizationModel {
 		return nil
 	}
 
-	if err = protojson.Unmarshal([]byte(*jsonModel), &pbModel); err != nil {
+	if err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(*jsonModel), &pbModel); err != nil {
 		return nil
 	}
 
 	return &pbModel
+}
+
+func (model *AuthzModel) GetSizeInKB() float64 {
+	pbModel := model.GetProtoModel()
+	if pbModel == nil {
+		return 0
+	}
+
+	sizeKB := float64(proto.Size(pbModel)) / 1024.0 //nolint:mnd
+
+	return math.Round(sizeKB*100) / 100 //nolint:mnd
 }
 
 func (model *AuthzModel) GetCreatedAt() *time.Time {
@@ -318,6 +332,11 @@ func (model *AuthzModel) DisplayAsJSON(fields []string) AuthzModel {
 		newModel.Conditions = model.Conditions
 	}
 
+	if slices.Contains(fields, "size") {
+		size := model.GetSizeInKB()
+		newModel.SizeKB = &size
+	}
+
 	return newModel
 }
 
@@ -328,23 +347,7 @@ func (model *AuthzModel) DisplayAsDSL(fields []string) (*string, error) {
 		fields = append(fields, "model")
 	}
 
-	dslModel := ""
-
-	if slices.Contains(fields, "id") {
-		if model.ID != nil {
-			dslModel += fmt.Sprintf("# Model ID: %v\n", *model.ID)
-		} else {
-			dslModel += fmt.Sprintf("# Model ID: %v\n", "N/A")
-		}
-	}
-
-	if slices.Contains(fields, "created_at") {
-		if model.CreatedAt != nil {
-			dslModel += fmt.Sprintf("# Created At: %v\n", *model.CreatedAt)
-		} else {
-			dslModel += fmt.Sprintf("# Created At: %v\n", "N/A")
-		}
-	}
+	dslModel := model.buildDSLMetadata(fields)
 
 	if slices.Contains(fields, "model") {
 		modelJSON, err := model.GetAsJSONString()
@@ -366,6 +369,32 @@ func (model *AuthzModel) DisplayAsDSL(fields []string) (*string, error) {
 	}
 
 	return &dslModel, nil
+}
+
+func (model *AuthzModel) buildDSLMetadata(fields []string) string {
+	metadata := ""
+
+	if slices.Contains(fields, "id") {
+		if model.ID != nil {
+			metadata += fmt.Sprintf("# Model ID: %v\n", *model.ID)
+		} else {
+			metadata += fmt.Sprintf("# Model ID: %v\n", "N/A")
+		}
+	}
+
+	if slices.Contains(fields, "created_at") {
+		if model.CreatedAt != nil {
+			metadata += fmt.Sprintf("# Created At: %v\n", *model.CreatedAt)
+		} else {
+			metadata += fmt.Sprintf("# Created At: %v\n", "N/A")
+		}
+	}
+
+	if slices.Contains(fields, "size") {
+		metadata += fmt.Sprintf("# Size: %.2f KB\n", model.GetSizeInKB())
+	}
+
+	return metadata
 }
 
 func (model *AuthzModel) setCreatedAt() {

--- a/internal/authorizationmodel/model_test.go
+++ b/internal/authorizationmodel/model_test.go
@@ -1,10 +1,13 @@
 package authorizationmodel_test
 
 import (
+	"math"
+	"strings"
 	"testing"
 
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/openfga/pkg/typesystem"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/openfga/cli/internal/authorizationmodel"
 )
@@ -122,5 +125,109 @@ func TestDisplayAsJsonWithFields(t *testing.T) {
 
 	if jsonModel2.GetTypeDefinitions() != nil {
 		t.Errorf("Expected %v to equal nil", jsonModel2.GetTypeDefinitions())
+	}
+}
+
+func TestGetSizeInKB(t *testing.T) {
+	t.Parallel()
+
+	typeDefs := []openfga.TypeDefinition{{Type: typeName}}
+	model := authorizationmodel.AuthzModel{
+		SchemaVersion:   openfga.PtrString(typesystem.SchemaVersion1_1),
+		ID:              openfga.PtrString(modelID),
+		TypeDefinitions: &typeDefs,
+	}
+
+	size := model.GetSizeInKB()
+	if size <= 0 {
+		t.Errorf("Expected positive size, got %v", size)
+	}
+
+	pbModel := model.GetProtoModel()
+
+	bytes, err := proto.Marshal(pbModel)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	expected := math.Round(float64(len(bytes))/1024.0*100) / 100
+	if size != expected {
+		t.Errorf("Expected %v to equal %v", size, expected)
+	}
+
+	if size != math.Round(size*100)/100 {
+		t.Errorf("Expected %v to be rounded to 2 decimal places", size)
+	}
+}
+
+func TestGetSizeInKBWithCreatedAt(t *testing.T) {
+	t.Parallel()
+
+	model := authorizationmodel.AuthzModel{}
+	model.Set(openfga.AuthorizationModel{
+		Id:              modelID,
+		SchemaVersion:   typesystem.SchemaVersion1_1,
+		TypeDefinitions: []openfga.TypeDefinition{{Type: typeName}},
+	})
+
+	if model.GetCreatedAt() == nil {
+		t.Fatalf("expected CreatedAt to be populated by Set")
+	}
+
+	size := model.GetSizeInKB()
+	if size <= 0 {
+		t.Errorf("Expected positive size for store-fetched model, got %v", size)
+	}
+}
+
+func TestDisplayAsJSONWithSize(t *testing.T) {
+	t.Parallel()
+
+	typeDefs := []openfga.TypeDefinition{{Type: typeName}}
+	model := authorizationmodel.AuthzModel{
+		SchemaVersion:   openfga.PtrString(typesystem.SchemaVersion1_1),
+		ID:              openfga.PtrString(modelID),
+		TypeDefinitions: &typeDefs,
+	}
+
+	withSize := model.DisplayAsJSON([]string{"model", "size"})
+	if withSize.SizeKB == nil {
+		t.Fatalf("Expected SizeKB to be set")
+	}
+
+	if *withSize.SizeKB != model.GetSizeInKB() {
+		t.Errorf("Expected %v to equal %v", *withSize.SizeKB, model.GetSizeInKB())
+	}
+
+	withoutSize := model.DisplayAsJSON([]string{"model"})
+	if withoutSize.SizeKB != nil {
+		t.Errorf("Expected SizeKB to be nil, got %v", *withoutSize.SizeKB)
+	}
+}
+
+func TestDisplayAsDSLWithSize(t *testing.T) {
+	t.Parallel()
+
+	model := authorizationmodel.AuthzModel{}
+	if err := model.ReadFromDSLString("model\n  schema 1.1\n\ntype user\n"); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	withSize, err := model.DisplayAsDSL([]string{"model", "size"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(*withSize, "# Size: ") {
+		t.Errorf("Expected DSL output to contain a size comment, got %v", *withSize)
+	}
+
+	withoutSize, err := model.DisplayAsDSL([]string{"model"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(*withoutSize, "# Size: ") {
+		t.Errorf("Expected DSL output to omit size comment, got %v", *withoutSize)
 	}
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

We added `size_kb` to the output of `fga model get` and `fga model validate`

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->
closes #711 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `size` field option to the `fga model get` command for retrieving model size in kilobytes.
  * Model validation now includes model size (in KB) in the response.

* **Documentation**
  * Updated documentation for `fga model get` command to show the new `size` field option and sample responses.
  * Updated documentation for `fga model validate` command to include size information in response examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->