### PR TITLE
fix: attach SLSA provenance to draft release via gh release upload

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -237,13 +237,11 @@ jobs:
     with:
       base64-subjects-as-file: "${{ needs.goreleaser.outputs.subjects-as-file }}"
       provenance-name: "fga.intoto.jsonl"
-      # Do NOT let the generator attach the provenance to the release. It would call
-      # softprops/action-gh-release@v2.2.1, whose draft lookup reassigns the match on every
-      # page of releases instead of breaking on first hit. Once this repo has >100 releases
-      # (2 pages), the fresh draft on page 1 is clobbered by the empty page 2, the action falls
-      # through to createRelease(), and we end up with two drafts on the same tag. The provenance
-      # is always uploaded as a workflow artifact regardless, so we attach it ourselves below via
-      # `gh release upload`, which resolves the draft deterministically by tag.
+      # Don't let the generator attach the provenance:
+      # - it uses softprops/action-gh-release@v2.2.1, whose paginated draft lookup
+      #   creates a duplicate draft once a repo has >100 releases (2 pages)
+      # - the provenance is still published as a workflow artifact, so the
+      #   release-provenance job attaches it via `gh release upload` (by tag)
       upload-assets: false
 
   release-provenance:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -247,6 +247,7 @@ jobs:
   release-provenance:
     needs: [ binary-provenance ]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write # To add the provenance asset to the draft release.
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -237,9 +237,34 @@ jobs:
     with:
       base64-subjects-as-file: "${{ needs.goreleaser.outputs.subjects-as-file }}"
       provenance-name: "fga.intoto.jsonl"
-      upload-assets: true
-      upload-tag-name: ${{ github.ref_name }}
-      draft-release: true
+      # Do NOT let the generator attach the provenance to the release. It would call
+      # softprops/action-gh-release@v2.2.1, whose draft lookup reassigns the match on every
+      # page of releases instead of breaking on first hit. Once this repo has >100 releases
+      # (2 pages), the fresh draft on page 1 is clobbered by the empty page 2, the action falls
+      # through to createRelease(), and we end up with two drafts on the same tag. The provenance
+      # is always uploaded as a workflow artifact regardless, so we attach it ourselves below via
+      # `gh release upload`, which resolves the draft deterministically by tag.
+      upload-assets: false
+
+  release-provenance:
+    needs: [ binary-provenance ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # To add the provenance asset to the draft release.
+    steps:
+      - name: Download the provenance
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: ${{ needs.binary-provenance.outputs.provenance-name }}
+
+      - name: Attach provenance to the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVENANCE: ${{ needs.binary-provenance.outputs.provenance-name }}
+        run: |
+          set -euo pipefail
+          gh release upload "$GITHUB_REF_NAME" "$PROVENANCE" \
+            --repo "$GITHUB_REPOSITORY" --clobber
 
   image-provenance:
     needs: [ goreleaser ]
@@ -258,7 +283,7 @@ jobs:
       registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
   undraft-release:
-    needs: [ binary-provenance, image-provenance ]
+    needs: [ release-provenance, image-provenance ]
     permissions:
       contents: write
     uses: openfga/.github/.github/workflows/undraft-release.yml@main

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -230,7 +230,8 @@ jobs:
     permissions:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
-      contents: read
+      # write required even with upload-assets:false due to slsa-framework/slsa-github-generator#2044
+      contents: write
 
     # Note: this _must_ be referenced by tag. See: https://github.com/slsa-framework/slsa-verifier/issues/12
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -230,7 +230,7 @@ jobs:
     permissions:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
-      contents: write # To add assets to a release.
+      contents: read
 
     # Note: this _must_ be referenced by tag. See: https://github.com/slsa-framework/slsa-verifier/issues/12
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0


### PR DESCRIPTION
The slsa-github-generator (pinned at v2.1.0) attaches provenance using softprops/action-gh-release@v2.2.1, whose draft lookup reassigns the match on every page of releases instead of breaking on first hit. Once a repo crosses 100 releases (2 pages), the fresh draft on page 1 is clobbered by the empty page 2, the action falls through to createRelease(), and two drafts end up on the same tag.

Set upload-assets: false so the generator no longer touches the release, and add a release-provenance job that downloads the provenance artifact and attaches it to goreleaser's single draft via 'gh release upload', which resolves the draft deterministically by tag.

The issue was first found out in the openfga/openfga repo while attempting the same pipeline for immutable tagging 

https://github.com/openfga/openfga/pull/3178#discussion_r3443529759


<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release workflow to optimize how provenance artifacts are handled during the draft release process. This change reorganizes artifact attachment timing and dependencies while maintaining existing verification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->