### PR TITLE
fix: publish distroless Docker image with dockers v2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -220,8 +220,16 @@ jobs:
             ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
         run: |
           set -euo pipefail
-          artifact=$(echo "$ARTIFACTS" | jq -r '[.[] | select (.type=="Docker Manifest")][0]')
-          image=$(echo "$artifact" | jq -r '.path' | cut -d':' -f1)
+          artifact=$(
+            echo "$ARTIFACTS" | jq -er --arg image_tag "openfga/cli:${GITHUB_REF_NAME}" '
+              [
+                .[]
+                | select(.type == "Docker Image")
+                | select(.path == $image_tag)
+                | select(((.extra.Platforms // []) | index("linux/amd64")) and ((.extra.Platforms // []) | index("linux/arm64")))
+              ][0]
+            '
+          )
           digest=$(echo "$artifact" | jq -r '.extra.Digest')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 

--- a/.goreleaser.Dockerfile
+++ b/.goreleaser.Dockerfile
@@ -1,3 +1,5 @@
-FROM scratch
-COPY fga /fga
+FROM gcr.io/distroless/static-debian13:nonroot
+
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/fga /fga
 ENTRYPOINT ["/fga"]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,11 +73,11 @@ docker_signs:
   - cmd: cosign
     env:
     - COSIGN_EXPERIMENTAL=1
-    artifacts: manifests
+    artifacts: images
     output: true
     args:
     - 'sign'
-    - '${artifact}'
+    - '${artifact}@${digest}'
     - "--yes" # needed on cosign 2.0.0+
 
 brews:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,68 +24,25 @@ builds:
       - "-X github.com/openfga/cli/internal/build.Commit={{.Commit}}"
       - "-X github.com/openfga/cli/internal/build.Date={{.Date}}"
 
-dockers:
-  - goos: linux
-    goarch: amd64
-
+dockers_v2:
+  - images:
+      - openfga/cli
+    tags:
+      - latest
+      - "{{ .Tag }}"
+      - "v{{ .Major }}"
+      - "v{{ .Major }}.{{ .Minor }}"
     dockerfile: .goreleaser.Dockerfile
-
-    image_templates:
-      - "openfga/cli:latest-amd64"
-      - "openfga/cli:{{ .Tag }}-amd64"
-      - "openfga/cli:v{{ .Version }}-amd64"
-      - "openfga/cli:v{{ .Major }}-amd64"
-      - "openfga/cli:v{{ .Major }}.{{ .Minor }}-amd64"
-      - "openfga/cli:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
-
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+    flags:
       - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-
-  - goos: linux
-    goarch: arm64
-
-    dockerfile: .goreleaser.Dockerfile
-
-    image_templates:
-      - "openfga/cli:latest-arm64"
-      - "openfga/cli:{{ .Tag }}-arm64"
-      - "openfga/cli:v{{ .Version }}-arm64"
-      - "openfga/cli:v{{ .Major }}-arm64"
-      - "openfga/cli:v{{ .Major }}.{{ .Minor }}-arm64"
-      - "openfga/cli:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
-
-    use: buildx
-
-    build_flag_templates:
-      - "--platform=linux/arm64"
-
-docker_manifests:
-  - name_template: openfga/cli:latest
-    image_templates:
-      - openfga/cli:latest-amd64
-      - openfga/cli:latest-arm64
-  - name_template: openfga/cli:v{{ .Version }}
-    image_templates:
-      - openfga/cli:v{{ .Version }}-amd64
-      - openfga/cli:v{{ .Version }}-arm64
-  - name_template: openfga/cli:v{{ .Major }}
-    image_templates:
-      - openfga/cli:v{{ .Major }}-amd64
-      - openfga/cli:v{{ .Major }}-arm64
-  - name_template: openfga/cli:v{{ .Major }}.{{ .Minor }}
-    image_templates:
-      - openfga/cli:v{{ .Major }}.{{ .Minor }}-amd64
-      - openfga/cli:v{{ .Major }}.{{ .Minor }}-arm64
-  - name_template: openfga/cli:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}
-    image_templates:
-      - openfga/cli:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64
-      - openfga/cli:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64
 
 release:
   draft: true

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ scoop install openfga
 docker pull openfga/cli; docker run -it openfga/cli
 ```
 
+The Docker image is multi-platform and includes the system CA certificates needed for endpoints that use publicly trusted certificate authorities. Private or internal CAs still need to be provided by the user.
+
 ### Go
 
 ```shell


### PR DESCRIPTION
## Summary
- Move the Docker image from `scratch` to `gcr.io/distroless/static-debian13:nonroot` so public CA roots are available in the container.
- Replace per-arch `dockers` + `docker_manifests` with GoReleaser `dockers_v2`, which is no longer experimental as of GoReleaser v2.16.
- Sign the published Docker image by immutable digest and select the released multi-platform digest by exact Git tag and platform metadata.

## Docs
- README Docker section now notes public CA support and calls out that private/internal CAs still need to be provided by the user.

## Validation
Ran:
- `make build`
- `go test ./...`
- `goreleaser release --clean --config .goreleaser.yaml --snapshot --skip sign,publish,announce,docker`
- focused `dockers_v2` GoReleaser validation with a local fake Docker shim
- GoReleaser v2.16 Docker signing tests for `DockerImageV2` artifact selection
- workflow digest `jq` check against a representative multi-platform `Docker Image` artifact

Reviewer command with Docker available:
- `goreleaser release --clean --config .goreleaser.yaml --snapshot --skip sign,publish,announce`

Reference: https://goreleaser.com/blog/goreleaser-v2.16/#docker-v2-is-no-longer-experimental

Fixes https://github.com/openfga/cli/issues/639