### PR TITLE
feat: add --name filter to store list

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ fga store **list**
 
 ###### Parameters
 * `--max-pages`: Max number of pages to retrieve (default: 20)
+* `--name`: Filter stores by name
 
 ###### Example
 `fga store list`

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ custom-headers:
 | [Create a Store](#create-store) | `create` | `--name`        | `fga store create --name="FGA Demo Store"`               |
 | [Import a Store](#import-store) | `import` | `--file`        | `fga store import --file store.fga.yaml`                 |
 | [Export a Store](#export-store) | `export` | `--store-id`    | `fga store export --store-id=01H0H015178Y2V4CX10C2KGHF4` |
-| [List Stores](#list-stores)     | `list`   |                 | `fga store list`                                         |
+| [List Stores](#list-stores)     | `list`   | `--name`        | `fga store list --name="FGA Demo Store"`                 |
 | [Get a Store](#get-store)       | `get`    | `--store-id`    | `fga store get --store-id=01H0H015178Y2V4CX10C2KGHF4`    |
 | [Delete a Store](#delete-store) | `delete` | `--store-id`    | `fga store delete --store-id=01H0H015178Y2V4CX10C2KGHF4` |
 
@@ -364,10 +364,12 @@ fga store **list**
 
 ###### Parameters
 * `--max-pages`: Max number of pages to retrieve (default: 20)
-* `--name`: Filter stores by name
+* `--name`: Filter stores by exact name (substrings and regexes are not supported)
 
 ###### Example
 `fga store list`
+
+`fga store list --name="FGA Demo Store"`
 
 ###### Response
 ```json

--- a/cmd/store/list.go
+++ b/cmd/store/list.go
@@ -31,7 +31,7 @@ import (
 // MaxStoresPagesLength Limit the pages of stores so that we are not paginating indefinitely.
 var MaxStoresPagesLength = 20 // up to 1000 records
 
-func listStores(ctx context.Context, fgaClient client.SdkClient, maxPages int) (*openfga.ListStoresResponse, error) {
+func listStores(ctx context.Context, fgaClient client.SdkClient, maxPages int, name string) (*openfga.ListStoresResponse, error) {
 	stores := []openfga.Store{}
 	continuationToken := ""
 	pageIndex := 0
@@ -39,6 +39,9 @@ func listStores(ctx context.Context, fgaClient client.SdkClient, maxPages int) (
 	for {
 		options := client.ClientListStoresOptions{
 			ContinuationToken: &continuationToken,
+		}
+		if name != "" {
+			options.Name = &name
 		}
 
 		response, err := fgaClient.ListStores(ctx).Options(options).Execute()
@@ -78,7 +81,12 @@ var listCmd = &cobra.Command{
 			return fmt.Errorf("failed to parse max pages due to %w", err)
 		}
 
-		response, err := listStores(cmd.Context(), fgaClient, maxPages)
+		name, err := cmd.Flags().GetString("name")
+		if err != nil {
+			return fmt.Errorf("failed to parse name due to %w", err)
+		}
+
+		response, err := listStores(cmd.Context(), fgaClient, maxPages, name)
 		if err != nil {
 			return err
 		}
@@ -89,4 +97,5 @@ var listCmd = &cobra.Command{
 
 func init() {
 	listCmd.Flags().Int("max-pages", MaxStoresPagesLength, "Max number of pages to get.")
+	listCmd.Flags().String("name", "", "Filter stores by name.")
 }

--- a/cmd/store/list.go
+++ b/cmd/store/list.go
@@ -31,7 +31,12 @@ import (
 // MaxStoresPagesLength Limit the pages of stores so that we are not paginating indefinitely.
 var MaxStoresPagesLength = 20 // up to 1000 records
 
-func listStores(ctx context.Context, fgaClient client.SdkClient, maxPages int, name string) (*openfga.ListStoresResponse, error) {
+func listStores(
+	ctx context.Context,
+	fgaClient client.SdkClient,
+	maxPages int,
+	name string,
+) (*openfga.ListStoresResponse, error) {
 	stores := []openfga.Store{}
 	continuationToken := ""
 	pageIndex := 0

--- a/cmd/store/list.go
+++ b/cmd/store/list.go
@@ -102,5 +102,5 @@ var listCmd = &cobra.Command{
 
 func init() {
 	listCmd.Flags().Int("max-pages", MaxStoresPagesLength, "Max number of pages to get.")
-	listCmd.Flags().String("name", "", "Filter stores by name.")
+	listCmd.Flags().String("name", "", "Filter stores by exact name. Substrings and regexes are not supported.")
 }

--- a/cmd/store/list_test.go
+++ b/cmd/store/list_test.go
@@ -36,7 +36,7 @@ func TestListStoresError(t *testing.T) {
 	mockRequest.EXPECT().Options(options).Return(mockExecute)
 	mockFgaClient.EXPECT().ListStores(t.Context()).Return(mockRequest)
 
-	_, err := listStores(t.Context(), mockFgaClient, 5)
+	_, err := listStores(t.Context(), mockFgaClient, 5, "")
 	if err == nil {
 		t.Error("Expect error but there is none")
 	}
@@ -67,7 +67,7 @@ func TestListStoresEmpty(t *testing.T) {
 	mockRequest.EXPECT().Options(options).Return(mockExecute)
 	mockFgaClient.EXPECT().ListStores(t.Context()).Return(mockRequest)
 
-	output, err := listStores(t.Context(), mockFgaClient, 5)
+	output, err := listStores(t.Context(), mockFgaClient, 5, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -118,7 +118,7 @@ func TestListStoresSinglePage(t *testing.T) {
 	mockRequest.EXPECT().Options(options).Return(mockExecute)
 	mockFgaClient.EXPECT().ListStores(t.Context()).Return(mockRequest)
 
-	output, err := listStores(t.Context(), mockFgaClient, 5)
+	output, err := listStores(t.Context(), mockFgaClient, 5, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -202,7 +202,7 @@ func TestListStoresMultiPage(t *testing.T) {
 		mockFgaClient.EXPECT().ListStores(t.Context()).Return(mockRequest2),
 	)
 
-	output, err := listStores(t.Context(), mockFgaClient, 5)
+	output, err := listStores(t.Context(), mockFgaClient, 5, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -256,7 +256,7 @@ func TestListStoresMultiPageMaxPage(t *testing.T) {
 	mockRequest1.EXPECT().Options(options1).Return(mockExecute1)
 	mockFgaClient.EXPECT().ListStores(t.Context()).Return(mockRequest1)
 
-	output, err := listStores(t.Context(), mockFgaClient, 1)
+	output, err := listStores(t.Context(), mockFgaClient, 1, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -270,5 +270,37 @@ func TestListStoresMultiPageMaxPage(t *testing.T) {
 
 	if string(outputTxt) != expectedOutput {
 		t.Errorf("Expected output %v actual %v", expectedOutput, string(outputTxt))
+	}
+}
+
+func TestListStoresWithName(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	const storeName = "my-store"
+
+	mockFgaClient := mockclient.NewMockSdkClient(mockCtrl)
+
+	mockExecute := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+
+	response := openfga.ListStoresResponse{
+		Stores:            []openfga.Store{},
+		ContinuationToken: "",
+	}
+	mockExecute.EXPECT().Execute().Return(&response, nil)
+
+	mockRequest := mockclient.NewMockSdkClientListStoresRequestInterface(mockCtrl)
+	options := client.ClientListStoresOptions{
+		ContinuationToken: openfga.PtrString(""),
+		Name:              openfga.PtrString(storeName),
+	}
+	mockRequest.EXPECT().Options(options).Return(mockExecute)
+	mockFgaClient.EXPECT().ListStores(t.Context()).Return(mockRequest)
+
+	_, err := listStores(t.Context(), mockFgaClient, 5, storeName)
+	if err != nil {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
Adds a `--name` flag to `fga store list` so you can filter stores by name, matching the filter the ListStores API already supports.

The flag binds to a string that gets passed through as `Name` on `ClientListStoresOptions`. It's only set when non-empty, so the default `fga store list` behaves exactly as before and the existing pagination path is untouched.

```
fga store list --name my-store
```

Fixes #552. The issue was assigned back in Hacktoberfest 2025 but no PR ever came of it, so picking it up here.

### Testing
Added `TestListStoresWithName` which asserts `--name` reaches the SDK options via the gomock `Options(...)` expectation, alongside the existing list tests (updated for the new param). `go build ./...`, `go vet ./cmd/store/...`, `gofmt -l`, and `go test ./cmd/store/...` all pass. Also updated the store-list parameter list in the README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--name` filter to the `fga store list` command.
  * Users can now list stores matching a specified name.

* **Documentation**
  * Documented the new `--name` option and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->